### PR TITLE
fix: resolve alarm handlers to support attribute=0

### DIFF
--- a/moto-hses-mock/src/handlers.rs
+++ b/moto-hses-mock/src/handlers.rs
@@ -36,15 +36,29 @@ impl CommandHandler for AlarmDataHandler {
                                                               // data[12..28] and data[28..60] remain 0 (default time and name)
         } else {
             let alarm = &state.alarms[instance - 1];
-            let alarm_data = alarm.serialize(attribute)?;
 
-            // Copy alarm data to appropriate positions
-            if alarm_data.len() >= 8 {
-                data[0..8].copy_from_slice(&alarm_data[0..8]);
+            if attribute == 0 {
+                // For attribute 0, return complete alarm data
+                let alarm_data = alarm.serialize_complete()?;
+
+                // Copy complete alarm data to response
+                if alarm_data.len() >= 60 {
+                    data[..60].copy_from_slice(&alarm_data[..60]);
+                } else {
+                    data[..alarm_data.len()].copy_from_slice(&alarm_data);
+                }
+            } else {
+                // For specific attributes, use the existing logic
+                let alarm_data = alarm.serialize(attribute)?;
+
+                // Copy alarm data to appropriate positions
+                if alarm_data.len() >= 8 {
+                    data[0..8].copy_from_slice(&alarm_data[0..8]);
+                }
+                // Fill remaining fields with default values
+                data[8..12].copy_from_slice(&0u32.to_le_bytes()); // Default alarm type
+                                                                  // data[12..28] and data[28..60] remain 0 (default time and name)
             }
-            // Fill remaining fields with default values
-            data[8..12].copy_from_slice(&0u32.to_le_bytes()); // Default alarm type
-                                                              // data[12..28] and data[28..60] remain 0 (default time and name)
         }
 
         Ok(data)
@@ -448,15 +462,29 @@ impl CommandHandler for AlarmInfoHandler {
                                                               // data[12..28] and data[28..60] remain 0 (default time and name)
         } else {
             let alarm = &state.alarms[alarm_number - 1];
-            let alarm_data = alarm.serialize(attribute)?;
 
-            // Copy alarm data to appropriate positions
-            if alarm_data.len() >= 8 {
-                data[0..8].copy_from_slice(&alarm_data[0..8]);
+            if attribute == 0 {
+                // For attribute 0, return complete alarm data
+                let alarm_data = alarm.serialize_complete()?;
+
+                // Copy complete alarm data to response
+                if alarm_data.len() >= 60 {
+                    data[..60].copy_from_slice(&alarm_data[..60]);
+                } else {
+                    data[..alarm_data.len()].copy_from_slice(&alarm_data);
+                }
+            } else {
+                // For specific attributes, use the existing logic
+                let alarm_data = alarm.serialize(attribute)?;
+
+                // Copy alarm data to appropriate positions
+                if alarm_data.len() >= 8 {
+                    data[0..8].copy_from_slice(&alarm_data[0..8]);
+                }
+                // Fill remaining fields with default values
+                data[8..12].copy_from_slice(&0u32.to_le_bytes()); // Default alarm type
+                                                                  // data[12..28] and data[28..60] remain 0 (default time and name)
             }
-            // Fill remaining fields with default values
-            data[8..12].copy_from_slice(&0u32.to_le_bytes()); // Default alarm type
-                                                              // data[12..28] and data[28..60] remain 0 (default time and name)
         }
 
         Ok(data)


### PR DESCRIPTION
## Overview

This PR fixes the InvalidAttribute error that was occurring when clients request alarm data with attribute=0 for commands 0x70 and 0x71.

## Major Changes

- 🐛 **Fix**: Add special handling for attribute=0 in AlarmDataHandler and AlarmInfoHandler
- 🔧 **Improvement**: Use serialize_complete() to return full alarm data when attribute=0
- 🐛 **Fix**: Resolve test failures in 0x70 and 0x71 alarm commands

## Technical Details

- When attribute=0, the handlers now call `alarm.serialize_complete()` instead of `alarm.serialize(attribute)`
- This provides the complete 60-byte alarm data structure that clients expect
- For attribute values 1-8, the existing behavior is preserved

## Testing

- All pre-push checks pass (formatting, clippy, tests, security audit)
- Manual testing confirmed that alarm commands 0x70 and 0x71 now work correctly
- Client-side tests that were previously failing now pass

## Breaking Changes

None - this is a backward-compatible fix that adds support for attribute=0 while preserving existing functionality.

## Related Issues

Fixes alarm command test failures in FS100 client integration tests.