### PR TITLE
fix: Remove unnecessary StatusWrapper and correct Status data size to 8 bytes

### DIFF
--- a/moto-hses-client/src/protocol.rs
+++ b/moto-hses-client/src/protocol.rs
@@ -3,8 +3,8 @@
 use moto_hses_proto::alarm::ReadAlarmHistory;
 use moto_hses_proto::{
     Alarm, Command, CoordinateSystemType, Position, ReadAlarmData, ReadCurrentPosition, ReadStatus,
-    ReadStatusData1, ReadStatusData2, ReadVar, Status, StatusData1, StatusData2, StatusWrapper,
-    VariableType, WriteVar,
+    ReadStatusData1, ReadStatusData2, ReadVar, Status, StatusData1, StatusData2, VariableType,
+    WriteVar,
 };
 use std::sync::atomic::Ordering;
 use tokio::time::{sleep, timeout};
@@ -38,8 +38,7 @@ impl HsesClient {
     /// Uses service=0x01 (Get_Attribute_All) with attribute=0 to get both data in one request
     pub async fn read_status(&self) -> Result<Status, ClientError> {
         let response = self.send_command_with_retry(ReadStatus).await?;
-        let result: StatusWrapper = self.deserialize_response(&response)?;
-        Ok(result.into())
+        self.deserialize_response(&response)
     }
 
     /// Read status data 1 (basic status information)

--- a/moto-hses-proto/src/lib.rs
+++ b/moto-hses-proto/src/lib.rs
@@ -16,7 +16,7 @@ pub use message::{
     HsesResponseSubHeader,
 };
 pub use position::{CartesianPosition, Position, PulsePosition};
-pub use status::{Status, StatusData1, StatusData2, StatusWrapper};
+pub use status::{Status, StatusData1, StatusData2};
 pub use types::{
     Command, CoordinateSystem, CoordinateSystemType, Division, ReadCurrentPosition, ReadStatus,
     ReadStatusData1, ReadStatusData2, ReadVar, Service, VarType, Variable, VariableType, WriteVar,

--- a/moto-hses-proto/src/types.rs
+++ b/moto-hses-proto/src/types.rs
@@ -154,7 +154,7 @@ pub struct ReadCurrentPosition {
 
 // Command implementations
 impl Command for ReadStatus {
-    type Response = crate::status::StatusWrapper;
+    type Response = crate::status::Status;
     fn command_id() -> u16 {
         0x72
     }


### PR DESCRIPTION
## Overview
This PR removes the unnecessary StatusWrapper and corrects the Status data size to comply with the HSES protocol specification.

## Changes

### 1. StatusWrapper Removal
- Removed unnecessary StatusWrapper struct and its implementations
- The wrapper was not needed since no Orphan Rule violation was occurring
- Eliminated unnecessary  conversion in client code

### 2. Status Data Size Correction
- Fixed Status total size from 4 bytes to 8 bytes
- Updated Data1 and Data2 from 2 bytes each to 4 bytes each
- Now compliant with HSES protocol specification (32-bit integers, 4 bytes each)

### 3. Implementation Details
- Changed StatusData1 and StatusData2 serialization from u16 to u32
- Updated test code to use 8-byte format
- All tests pass and comply with specification

## Test Results
- All 9 Status-related tests pass
- Protocol communication tests work correctly
- No linter errors

## Impact
- moto-hses-proto: Status-related structures and implementations
- moto-hses-client: Simplified protocol communication

This fix makes the code more concise and fully compliant with the HSES protocol specification.