### PR TITLE
feat: implement 0x82 alarm reset and error cancel commands

### DIFF
--- a/moto-hses-client/examples/alarm_operations.rs
+++ b/moto-hses-client/examples/alarm_operations.rs
@@ -264,6 +264,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    println!("\n--- Alarm operations example completed successfully ---");
+    // Test 0x82 Alarm Reset / Error Cancel Commands
+    println!("\n--- 0x82 Alarm Reset / Error Cancel Commands ---");
+
+    // Test alarm reset command
+    println!("\n--- Alarm Reset Command (0x82, Instance 1) ---");
+    match client.reset_alarm().await {
+        Ok(_) => {
+            println!("✓ Alarm reset command executed successfully");
+        }
+        Err(e) => {
+            println!("✗ Alarm reset command failed: {}", e);
+        }
+    }
+
+    // Test error cancel command
+    println!("\n--- Error Cancel Command (0x82, Instance 2) ---");
+    match client.cancel_error().await {
+        Ok(_) => {
+            println!("✓ Error cancel command executed successfully");
+        }
+        Err(e) => {
+            println!("✗ Error cancel command failed: {}", e);
+        }
+    }
+
     Ok(())
 }

--- a/moto-hses-client/src/protocol.rs
+++ b/moto-hses-client/src/protocol.rs
@@ -1,6 +1,6 @@
 //! Protocol communication for HSES client
 
-use moto_hses_proto::alarm::ReadAlarmHistory;
+use moto_hses_proto::alarm::{AlarmReset, ReadAlarmHistory};
 use moto_hses_proto::{
     Alarm, Command, CoordinateSystemType, ExecutingJobInfo, Position, ReadAlarmData,
     ReadCurrentPosition, ReadExecutingJobInfo, ReadIo, ReadStatus, ReadStatusData1,
@@ -82,6 +82,24 @@ impl HsesClient {
     ) -> Result<Alarm, ClientError> {
         let command = ReadAlarmHistory::new(instance, attribute);
         self.read_alarm_attribute(command, attribute).await
+    }
+
+    /// Reset alarm (0x82 command with instance 1)
+    ///
+    /// This command resets the current alarm state.
+    pub async fn reset_alarm(&self) -> Result<(), ClientError> {
+        let command = AlarmReset::reset();
+        let _response = self.send_command_with_retry(command).await?;
+        Ok(())
+    }
+
+    /// Cancel error (0x82 command with instance 2)
+    ///
+    /// This command cancels the current error state.
+    pub async fn cancel_error(&self) -> Result<(), ClientError> {
+        let command = AlarmReset::cancel();
+        let _response = self.send_command_with_retry(command).await?;
+        Ok(())
     }
 
     /// Read executing job information

--- a/scripts/integration_test.toml
+++ b/scripts/integration_test.toml
@@ -242,9 +242,14 @@ pattern = "✓ Invalid instance correctly returned empty data"
 description = "Alarm history - Invalid instance handling"
 
 [[tests.alarm_operations.expected_outputs]]
-type = "completion"
-pattern = "Alarm operations example completed successfully"
-description = "Alarm operations completion"
+type = "alarm_reset_command"
+pattern = "✓ Alarm reset command executed successfully"
+description = "0x82 Alarm Reset Command (Instance 1)"
+
+[[tests.alarm_operations.expected_outputs]]
+type = "error_cancel_command"
+pattern = "✓ Error cancel command executed successfully"
+description = "0x82 Error Cancel Command (Instance 2)"
 
 [tests.connection_management]
 command = "connection_management"


### PR DESCRIPTION
## Overview

This PR implements the 0x82 command (Alarm Reset / Error Cancel) according to the HSES protocol specification, providing functionality to reset alarms and cancel errors on robot controllers.

## Major Changes

- ✨ **Feature**: Implement 0x82 Alarm Reset / Error Cancel command
- 🔧 **Improvement**: Add comprehensive client API methods for alarm operations
- 🏗️ **Refactor**: Enhance alarm operations example with new functionality

## Technical Details

- Added  enum with  (instance 1) and  (instance 2) variants
- Implemented  struct with full  trait support
- Added  and  methods to 
- Command follows HSES protocol specification:
  - Command ID: 0x82
  - Instance: 1 (RESET) / 2 (CANCEL)
  - Attribute: 1 (fixed)
  - Service: 0x10 (Set_Attribute_Single)
  - Payload: 4 bytes [1, 0, 0, 0] (fixed value 1 + reserved)

## Testing

- Added comprehensive unit tests for 0x82 command implementation
- Updated integration tests to verify command execution
- All existing tests continue to pass
- Integration test coverage includes:
  - Command execution verification
  - Protocol compliance validation
  - Error handling scenarios

## Breaking Changes

None - this is a purely additive feature that extends existing functionality.

## Related Issues

Implements 0x82 command as specified in HSES protocol documentation.