### PR TITLE
refactor: unify file operations and improve test coverage

### DIFF
--- a/moto-hses-proto/src/file.rs
+++ b/moto-hses-proto/src/file.rs
@@ -1,0 +1,226 @@
+//! File control commands for HSES protocol
+
+use crate::error::ProtocolError;
+use crate::types::Command;
+
+/// File list request command
+#[derive(Debug, Clone)]
+pub struct ReadFileList;
+
+impl Command for ReadFileList {
+    type Response = Vec<String>;
+
+    fn command_id() -> u16 {
+        0x0000
+    }
+
+    fn instance(&self) -> u16 {
+        0
+    }
+
+    fn attribute(&self) -> u8 {
+        0
+    }
+
+    fn service(&self) -> u8 {
+        0x32
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+        Ok(vec![])
+    }
+}
+
+/// Send file command
+#[derive(Debug, Clone)]
+pub struct SendFile {
+    pub filename: String,
+    pub content: Vec<u8>,
+}
+
+impl SendFile {
+    pub fn new(filename: String, content: Vec<u8>) -> Self {
+        Self { filename, content }
+    }
+}
+
+impl Command for SendFile {
+    type Response = ();
+
+    fn command_id() -> u16 {
+        0x0000
+    }
+
+    fn instance(&self) -> u16 {
+        0
+    }
+
+    fn attribute(&self) -> u8 {
+        0
+    }
+
+    fn service(&self) -> u8 {
+        0x15
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+        let mut payload = self.filename.as_bytes().to_vec();
+        payload.push(0); // Null terminator
+        payload.extend_from_slice(&self.content);
+        Ok(payload)
+    }
+}
+
+/// Receive file command
+#[derive(Debug, Clone)]
+pub struct ReceiveFile {
+    pub filename: String,
+}
+
+impl ReceiveFile {
+    pub fn new(filename: String) -> Self {
+        Self { filename }
+    }
+}
+
+impl Command for ReceiveFile {
+    type Response = Vec<u8>;
+
+    fn command_id() -> u16 {
+        0x0000
+    }
+
+    fn instance(&self) -> u16 {
+        0
+    }
+
+    fn attribute(&self) -> u8 {
+        0
+    }
+
+    fn service(&self) -> u8 {
+        0x16
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+        let mut payload = self.filename.as_bytes().to_vec();
+        payload.push(0); // Null terminator
+        Ok(payload)
+    }
+}
+
+/// Delete file command
+#[derive(Debug, Clone)]
+pub struct DeleteFile {
+    pub filename: String,
+}
+
+impl DeleteFile {
+    pub fn new(filename: String) -> Self {
+        Self { filename }
+    }
+}
+
+impl Command for DeleteFile {
+    type Response = ();
+
+    fn command_id() -> u16 {
+        0x0000
+    }
+
+    fn instance(&self) -> u16 {
+        0
+    }
+
+    fn attribute(&self) -> u8 {
+        0
+    }
+
+    fn service(&self) -> u8 {
+        0x09
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+        let mut payload = self.filename.as_bytes().to_vec();
+        payload.push(0); // Null terminator
+        Ok(payload)
+    }
+}
+
+/// File operation response parsers
+pub mod response {
+    use super::*;
+
+    /// Parse file list response
+    pub fn parse_file_list(data: &[u8]) -> Result<Vec<String>, ProtocolError> {
+        let content = String::from_utf8_lossy(data);
+        let files: Vec<String> = content
+            .split('\0')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+        Ok(files)
+    }
+
+    /// Parse file content response
+    pub fn parse_file_content(data: &[u8]) -> Result<Vec<u8>, ProtocolError> {
+        // Extract file content from response
+        // Response format: filename\0content
+        if let Some(null_pos) = data.iter().position(|&b| b == 0) {
+            let content = data[null_pos + 1..].to_vec();
+            Ok(content)
+        } else {
+            Ok(data.to_vec())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_file_list_serialization() {
+        let cmd = ReadFileList;
+        let data = cmd.serialize().unwrap();
+        assert_eq!(data, vec![]);
+    }
+
+    #[test]
+    fn test_read_file_list_deserialization() {
+        let data = b"file1.job\0file2.job\0";
+        let files = response::parse_file_list(data).unwrap();
+        assert_eq!(files, vec!["file1.job", "file2.job"]);
+    }
+
+    #[test]
+    fn test_send_file_serialization() {
+        let cmd = SendFile::new("test.job".to_string(), b"content".to_vec());
+        let data = cmd.serialize().unwrap();
+        let expected = b"test.job\0content".to_vec();
+        assert_eq!(data, expected);
+    }
+
+    #[test]
+    fn test_receive_file_serialization() {
+        let cmd = ReceiveFile::new("test.job".to_string());
+        let data = cmd.serialize().unwrap();
+        let expected = b"test.job\0".to_vec();
+        assert_eq!(data, expected);
+    }
+
+    #[test]
+    fn test_receive_file_deserialization() {
+        let data = b"test.job\0file content";
+        let content = response::parse_file_content(data).unwrap();
+        assert_eq!(content, b"file content".to_vec());
+    }
+
+    #[test]
+    fn test_delete_file_serialization() {
+        let cmd = DeleteFile::new("test.job".to_string());
+        let data = cmd.serialize().unwrap();
+        let expected = b"test.job\0".to_vec();
+        assert_eq!(data, expected);
+    }
+}

--- a/moto-hses-proto/src/lib.rs
+++ b/moto-hses-proto/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod alarm;
 pub mod error;
+pub mod file;
 pub mod job;
 pub mod message;
 pub mod position;
@@ -12,6 +13,8 @@ pub mod variables;
 // Re-export commonly used items for convenience
 pub use alarm::{Alarm, AlarmAttribute, ReadAlarmData};
 pub use error::ProtocolError;
+pub use file::response::{parse_file_content, parse_file_list};
+pub use file::{DeleteFile, ReadFileList, ReceiveFile, SendFile};
 pub use job::{ExecutingJobInfo, JobInfoAttribute, ReadExecutingJobInfo, TaskType};
 pub use message::{
     HsesCommonHeader, HsesRequestMessage, HsesRequestSubHeader, HsesResponseMessage,


### PR DESCRIPTION
## Overview

This PR unifies file operations implementation and improves test coverage by consolidating command sending methods and moving protocol-level logic to the appropriate crate.

## Major Changes

- ✨ **Feature**: Unified command sending methods with Division parameter
- 🔧 **Improvement**: Moved file operation commands to moto-hses-proto crate
- 🏗️ **Refactor**: Removed redundant send_file_command_* methods
- 🧪 **Test**: Improved file operations tests with proper assertions
- 📚 **Docs**: Updated examples to use HsesClient API

## Technical Details

- Added Division enum parameter to send_command_with_retry/send_command_once methods
- Removed duplicate send_file_command_* methods that were redundant
- Created file.rs module in moto-hses-proto with ReadFileList, SendFile, ReceiveFile, DeleteFile commands
- Updated file operations tests to use MockServer's initial state (TEST.JOB file) for assertions
- Refactored examples to use HsesClient API instead of low-level HsesRequestMessage

## Testing

- All existing tests pass
- File operations tests now verify MockServer's initial state
- Examples updated to use high-level client API
- Division enum provides type safety for command sending

## Breaking Changes

None - this is a refactoring that maintains API compatibility while improving internal structure.