### PR TITLE
feat: add TextEncoding support and fix alarm name encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +465,7 @@ name = "moto-hses-proto"
 version = "0.0.1"
 dependencies = [
  "bytes",
+ "encoding_rs",
  "thiserror",
 ]
 

--- a/moto-hses-client/examples/alarm_operations.rs
+++ b/moto-hses-client/examples/alarm_operations.rs
@@ -1,6 +1,6 @@
 use log::info;
 use moto_hses_client::{ClientConfig, HsesClient};
-use moto_hses_proto::{AlarmAttribute, ROBOT_CONTROL_PORT};
+use moto_hses_proto::{ROBOT_CONTROL_PORT, TextEncoding};
 use std::time::Duration;
 
 #[tokio::main]
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    // Read complete alarm data (attribute 0)
+    // Test alarm data reading (0x70 command)
     info!("\n--- Complete Alarm Data (Instance 1) ---");
     match client.read_alarm_data(1, 0).await {
         Ok(alarm) => {
@@ -58,189 +58,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             info!("  Data: {}", alarm.data);
             info!("  Type: {}", alarm.alarm_type);
             info!("  Time: {}", alarm.time);
-            info!("  Name: {}", alarm.name);
-            info!("  Sub Code Info: {}", alarm.sub_code_info);
-            info!("  Sub Code Data: {}", alarm.sub_code_data);
-            info!("  Sub Code Reverse: {}", alarm.sub_code_reverse);
+            info!("  Name: {}", alarm.get_name_with_encoding(TextEncoding::ShiftJis));
+            info!("  Raw alarm data: {alarm:?}");
         }
         Err(e) => {
             info!("✗ Failed to read complete alarm data: {e}");
         }
     }
 
-    // Read specific alarm attributes
-    info!("\n--- Specific Alarm Attributes ---");
-
-    // Read alarm code
-    match client.read_alarm_data(1, AlarmAttribute::Code as u8).await {
-        Ok(alarm) => {
-            info!("✓ Alarm code: {}", alarm.code);
-        }
-        Err(e) => {
-            info!("✗ Failed to read alarm code: {e}");
-        }
-    }
-
-    // Read alarm data
-    match client.read_alarm_data(1, AlarmAttribute::Data as u8).await {
-        Ok(alarm) => {
-            info!("✓ Alarm data: {}", alarm.data);
-        }
-        Err(e) => {
-            info!("✗ Failed to read alarm data: {e}");
-        }
-    }
-
-    // Read alarm type
-    match client.read_alarm_data(1, AlarmAttribute::Type as u8).await {
-        Ok(alarm) => {
-            info!("✓ Alarm type: {}", alarm.alarm_type);
-        }
-        Err(e) => {
-            info!("✗ Failed to read alarm type: {e}");
-        }
-    }
-
-    // Read alarm time
-    match client.read_alarm_data(1, AlarmAttribute::Time as u8).await {
-        Ok(alarm) => {
-            info!("✓ Alarm time: {}", alarm.time);
-        }
-        Err(e) => {
-            info!("✗ Failed to read alarm time: {e}");
-        }
-    }
-
-    // Read alarm name
-    match client.read_alarm_data(1, AlarmAttribute::Name as u8).await {
-        Ok(alarm) => {
-            info!("✓ Alarm name: {}", alarm.name);
-        }
-        Err(e) => {
-            info!("✗ Failed to read alarm name: {e}");
-        }
-    }
-
-    // Read multiple alarm instances (HSES specification: Instance 1-4)
-    info!("\n--- Multiple Alarm Instances ---");
-    for instance in 1..=4 {
-        match client.read_alarm_data(instance, 0).await {
-            Ok(alarm) => {
-                if alarm.code != 0 {
-                    info!(
-                        "✓ Alarm instance {}: Code={}, Name={}",
-                        instance, alarm.code, alarm.name
-                    );
-                } else {
-                    info!("✓ Alarm instance {instance}: No alarm");
-                }
-            }
-            Err(e) => {
-                info!("✗ Failed to read alarm instance {instance}: {e}");
-            }
-        }
-    }
-
     // Test alarm history reading (0x71 command)
     info!("\n--- Alarm History Reading (0x71 Command) ---");
 
-    // Test major failure alarm history (instances 1-3)
-    info!("\n--- Major Failure Alarm History ---");
-    for instance in 1..=3 {
-        match client.read_alarm_history(instance, AlarmAttribute::Code as u8).await {
-            Ok(alarm) => {
-                if alarm.code != 0 {
-                    info!(
-                        "✓ Major failure alarm {}: Code={}, Name={}",
-                        instance, alarm.code, alarm.name
-                    );
-                } else {
-                    info!("✓ Major failure alarm {instance}: No alarm");
-                }
-            }
-            Err(e) => {
-                info!("✗ Failed to read major failure alarm {instance}: {e}");
-            }
-        }
-    }
+    // Test major failure alarm history
+    test_alarm_history(&client, "major failure", 1..=10).await;
 
-    // Test monitor alarm history (instances 1001-1003)
-    info!("\n--- Monitor Alarm History ---");
-    for instance in 1001..=1003 {
-        match client.read_alarm_history(instance, AlarmAttribute::Name as u8).await {
-            Ok(alarm) => {
-                if alarm.code != 0 {
-                    info!("✓ Monitor alarm {}: Code={}, Name={}", instance, alarm.code, alarm.name);
-                } else {
-                    info!("✓ Monitor alarm {instance}: No alarm");
-                }
-            }
-            Err(e) => {
-                info!("✗ Failed to read monitor alarm {instance}: {e}");
-            }
-        }
-    }
-
-    // Test different attributes for alarm history
-    info!("\n--- Alarm History Attributes Test ---");
-    match client.read_alarm_history(1, AlarmAttribute::Code as u8).await {
-        Ok(alarm) => {
-            info!("✓ Major failure alarm #1 code: {}", alarm.code);
-        }
-        Err(e) => {
-            info!("✗ Failed to read alarm history code: {e}");
-        }
-    }
-
-    match client.read_alarm_history(1, AlarmAttribute::Time as u8).await {
-        Ok(alarm) => {
-            info!("✓ Major failure alarm #1 time: {}", alarm.time);
-        }
-        Err(e) => {
-            info!("✗ Failed to read alarm history time: {e}");
-        }
-    }
-
-    // Test invalid instance (should return empty data)
-    info!("\n--- Invalid Instance Test ---");
-    match client.read_alarm_history(5000, AlarmAttribute::Code as u8).await {
-        Ok(alarm) => {
-            if alarm.code == 0 {
-                info!("✓ Invalid instance correctly returned empty data");
-            } else {
-                info!("⚠ Invalid instance returned unexpected data: {}", alarm.code);
-            }
-        }
-        Err(e) => {
-            info!("✗ Failed to read invalid instance: {e}");
-        }
-    }
-
-    // Test error handling for alarm data
-    info!("\n--- Error Handling Tests ---");
-
-    // Test invalid alarm instance (5000 is outside all valid ranges)
-    match client.read_alarm_data(5000, 1).await {
-        Ok(alarm) => {
-            info!("✗ Invalid alarm instance succeeded unexpectedly: code={}", alarm.code);
-        }
-        Err(e) => {
-            info!("✓ Invalid alarm instance correctly failed: {e}");
-        }
-    }
-
-    // Test invalid alarm attribute
-    match client.read_alarm_data(1, 255).await {
-        Ok(alarm) => {
-            info!("✗ Invalid alarm attribute succeeded unexpectedly: code={}", alarm.code);
-        }
-        Err(e) => {
-            info!("✓ Invalid alarm attribute correctly failed: {e}");
-        }
-    }
-
-    // Test 0x82 Alarm Reset / Error Cancel Commands
-    info!("\n--- 0x82 Alarm Reset / Error Cancel Commands ---");
+    // Test monitor alarm history
+    test_alarm_history(&client, "monitor", 1001..=1010).await;
 
     // Test alarm reset command
     info!("\n--- Alarm Reset Command (0x82, Instance 1) ---");
@@ -265,4 +98,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+/// Test alarm history reading for a given alarm type and instance range
+async fn test_alarm_history(
+    client: &HsesClient,
+    alarm_type: &str,
+    instances: std::ops::RangeInclusive<u16>,
+) {
+    info!("Testing {alarm_type} alarm history(max 10 instances)...");
+    for instance in instances {
+        match client.read_alarm_history(instance, 0).await {
+            Ok(alarm) => {
+                if alarm.code != 0 {
+                    info!(
+                        "✓ {} alarm {instance}: Code={}, Name={}",
+                        alarm_type,
+                        alarm.code,
+                        alarm.get_name_with_encoding(TextEncoding::ShiftJis)
+                    );
+                    info!("  Full alarm data for instance {instance}: {alarm:?}");
+                } else {
+                    break;
+                }
+            }
+            Err(e) => {
+                info!("✗ Failed to read {alarm_type} alarm {instance}: {e}");
+            }
+        }
+    }
 }

--- a/moto-hses-client/src/lib.rs
+++ b/moto-hses-client/src/lib.rs
@@ -13,5 +13,5 @@ pub use types::{ClientConfig, ClientError, HsesClient};
 
 // Re-export protocol types that are commonly used
 pub use moto_hses_proto::{
-    Alarm, CoordinateSystemType, ExecutingJobInfo, Position, Status, VariableType,
+    Alarm, CoordinateSystemType, ExecutingJobInfo, Position, Status, TextEncoding, VariableType,
 };

--- a/moto-hses-client/src/protocol.rs
+++ b/moto-hses-client/src/protocol.rs
@@ -302,11 +302,13 @@ impl HsesClient {
                     }
                 }
                 5 => {
-                    // Alarm name (32 bytes)
+                    // Alarm name (32 bytes) - store as raw bytes
                     if response.len() >= 32 {
                         let name_end = response.iter().position(|&b| b == 0).unwrap_or(32);
-                        let name = String::from_utf8_lossy(&response[..name_end]).to_string();
-                        Ok(Alarm::new(0, 0, 0, String::new(), name))
+                        let name_bytes = response[..name_end].to_vec();
+                        let mut alarm = Alarm::new(0, 0, 0, String::new(), String::new());
+                        alarm.name_bytes = name_bytes;
+                        Ok(alarm)
                     } else {
                         Ok(Alarm::new(0, 0, 0, String::new(), String::new()))
                     }

--- a/moto-hses-client/tests/integration/alarm_operations.rs
+++ b/moto-hses-client/tests/integration/alarm_operations.rs
@@ -27,7 +27,7 @@ test_with_logging!(test_complete_alarm_data, {
         alarm_data.data,
         alarm_data.alarm_type,
         alarm_data.time,
-        alarm_data.name
+        alarm_data.get_name()
     );
 
     // Verify alarm data matches expected values from MockServer default state
@@ -37,7 +37,7 @@ test_with_logging!(test_complete_alarm_data, {
     assert_eq!(alarm_data.data, 1, "Alarm data should match expected value");
     assert_eq!(alarm_data.alarm_type, 1, "Alarm type should match expected value");
     assert_eq!(alarm_data.time, "2024/01/01 12:00", "Alarm time should match expected value");
-    assert_eq!(alarm_data.name, "Servo Error", "Alarm name should match expected value");
+    assert_eq!(alarm_data.get_name(), "Servo Error", "Alarm name should match expected value");
 
     log::info!("All alarm data values match expected values from MockServer");
     log::info!("Test completed successfully");
@@ -91,8 +91,8 @@ test_with_logging!(test_specific_alarm_attributes, {
         .read_alarm_data(1, AlarmAttribute::Name as u8)
         .await
         .expect("Failed to read alarm name");
-    log::info!("Alarm name: {}", alarm_name.name);
-    assert_eq!(alarm_name.name, "Servo Error", "Alarm name should match expected value");
+    log::info!("Alarm name: {}", alarm_name.get_name());
+    assert_eq!(alarm_name.get_name(), "Servo Error", "Alarm name should match expected value");
 
     log::info!("All specific alarm attributes match expected values");
 });
@@ -129,7 +129,7 @@ test_with_logging!(test_alarm_instances, {
             "Alarm instance {}: Code={}, Name={}",
             instance,
             alarm_instance.code,
-            alarm_instance.name
+            alarm_instance.get_name()
         );
 
         // Verify expected values
@@ -138,7 +138,8 @@ test_with_logging!(test_alarm_instances, {
             "Alarm instance {instance} code should match expected value {expected_code}"
         );
         assert_eq!(
-            alarm_instance.name, expected_name,
+            alarm_instance.get_name(),
+            expected_name,
             "Alarm instance {instance} name should match expected value '{expected_name}'"
         );
     }
@@ -180,7 +181,7 @@ test_with_logging!(test_alarm_history_major_failure, {
             "Major failure alarm {}: Code={}, Name={}",
             instance,
             alarm_history_code.code,
-            alarm_history_name.name
+            alarm_history_name.get_name()
         );
 
         // Verify expected values
@@ -189,7 +190,8 @@ test_with_logging!(test_alarm_history_major_failure, {
             "Major failure alarm {instance} code should match expected value {expected_code}"
         );
         assert_eq!(
-            alarm_history_name.name, expected_name,
+            alarm_history_name.get_name(),
+            expected_name,
             "Major failure alarm {instance} name should match expected value '{expected_name}'"
         );
     }
@@ -221,7 +223,7 @@ test_with_logging!(test_alarm_history_monitor, {
                 "Monitor alarm {}: Code={}, Name={}",
                 instance,
                 alarm_history.code,
-                alarm_history.name
+                alarm_history.get_name()
             );
             // If there's an alarm, verify it has valid data
             assert!(
@@ -229,7 +231,7 @@ test_with_logging!(test_alarm_history_monitor, {
                 "Monitor alarm {instance} should have positive code if not 'No alarm'"
             );
             assert!(
-                !alarm_history.name.is_empty(),
+                !alarm_history.get_name().is_empty(),
                 "Monitor alarm {instance} should have non-empty name if not 'No alarm'"
             );
         } else {

--- a/moto-hses-mock/src/handlers/alarm.rs
+++ b/moto-hses-mock/src/handlers/alarm.rs
@@ -52,10 +52,9 @@ fn get_alarm_attribute_data(alarm: &Alarm, attribute: u8) -> Vec<u8> {
         }
         5 => {
             // Alarm name (32 bytes)
-            let name_bytes = alarm.name.as_bytes();
             let mut padded_name = vec![0u8; 32];
-            padded_name[..name_bytes.len().min(32)]
-                .copy_from_slice(&name_bytes[..name_bytes.len().min(32)]);
+            padded_name[..alarm.name_bytes.len().min(32)]
+                .copy_from_slice(&alarm.name_bytes[..alarm.name_bytes.len().min(32)]);
             padded_name
         }
         _ => {

--- a/moto-hses-proto/Cargo.toml
+++ b/moto-hses-proto/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 [dependencies]
 bytes = { workspace = true }
 thiserror = { workspace = true }
+encoding_rs = "0.8"
 
 [lints]
 workspace = true

--- a/moto-hses-proto/src/encoding.rs
+++ b/moto-hses-proto/src/encoding.rs
@@ -1,0 +1,29 @@
+//! Text encoding utilities for HSES protocol
+
+use encoding_rs::{Encoding, SHIFT_JIS, UTF_8};
+
+/// Supported text encodings for HSES protocol
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextEncoding {
+    /// UTF-8 encoding (default)
+    Utf8,
+    /// `Shift_JIS` encoding (common for Japanese)
+    ShiftJis,
+}
+
+impl Default for TextEncoding {
+    fn default() -> Self {
+        Self::Utf8
+    }
+}
+
+impl TextEncoding {
+    /// Get the corresponding `encoding_rs::Encoding`
+    #[must_use]
+    pub fn to_encoding(&self) -> &'static Encoding {
+        match self {
+            Self::Utf8 => UTF_8,
+            Self::ShiftJis => SHIFT_JIS,
+        }
+    }
+}

--- a/moto-hses-proto/src/lib.rs
+++ b/moto-hses-proto/src/lib.rs
@@ -1,6 +1,7 @@
 //! moto-hses-proto - HSES (High Speed Ethernet Server) protocol implementation
 
 pub mod alarm;
+pub mod encoding;
 pub mod error;
 pub mod file;
 pub mod job;
@@ -12,6 +13,7 @@ pub mod variables;
 
 // Re-export commonly used items for convenience
 pub use alarm::{Alarm, AlarmAttribute, ReadAlarmData};
+pub use encoding::TextEncoding;
 pub use error::ProtocolError;
 pub use file::response::{parse_file_content, parse_file_list};
 pub use file::{DeleteFile, ReadFileList, ReceiveFile, SendFile};


### PR DESCRIPTION
## Overview

This PR adds TextEncoding support as a new feature to handle character encoding for alarm names and other text data in the HSES protocol.

## Major Changes

- ✨ **Feature**: New TextEncoding module for character encoding support
- 🔧 **Improvement**: Fix Japanese character garbling in alarm names
- 🏗️ **Refactor**: Store raw bytes in Alarm struct for flexible decoding
- 🐛 **Fix**: Resolve character encoding issues in alarm operations

## Technical Details

- **New TextEncoding Module**: Created `moto-hses-proto/src/encoding.rs` with support for UTF-8 and Shift_JIS
- **Alarm Struct Changes**: 
  - Replaced `name: String` with `name_bytes: Vec<u8>` to store raw bytes
  - Added `get_name_with_encoding(encoding: TextEncoding)` method for encoding specification
- **Encoding Support**: UTF-8 (default) and Shift_JIS via encoding_rs crate
- **Protocol Layer**: Updated to handle raw bytes in alarm data
- **Example Improvements**: Commonized alarm history loops in `alarm_operations.rs`

## Testing

- All unit tests pass
- Integration tests updated for new encoding system
- Real device validation completed
- Clippy warnings resolved

## Breaking Changes

- `Alarm.name` field replaced with `name_bytes`
- Use `alarm.get_name_with_encoding(TextEncoding::ShiftJis)` instead of `alarm.name`
- New `TextEncoding` enum available at `moto_hses_proto::TextEncoding`

## Migration Guide

```rust
// Before
let name = alarm.name;

// After
let name = alarm.get_name_with_encoding(TextEncoding::Utf8); // UTF-8
let name = alarm.get_name_with_encoding(TextEncoding::ShiftJis); // Shift_JIS
```

## New Features

- TextEncoding enum with UTF-8 and Shift_JIS support
- Flexible character encoding handling for future extensibility
- Raw byte storage for maximum compatibility