### PR TITLE
feat: implement unified text encoding system

### DIFF
--- a/moto-hses-client/examples/alarm_operations.rs
+++ b/moto-hses-client/examples/alarm_operations.rs
@@ -35,6 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         retry_count: 5,
         retry_delay: Duration::from_millis(200),
         buffer_size: 8192,
+        text_encoding: TextEncoding::ShiftJis,
     };
 
     // Connect to the controller
@@ -58,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             info!("  Data: {}", alarm.data);
             info!("  Type: {}", alarm.alarm_type);
             info!("  Time: {}", alarm.time);
-            info!("  Name: {}", alarm.get_name_with_encoding(TextEncoding::ShiftJis));
+            info!("  Name: {}", alarm.name);
             info!("  Raw alarm data: {alarm:?}");
         }
         Err(e) => {
@@ -113,9 +114,7 @@ async fn test_alarm_history(
                 if alarm.code != 0 {
                     info!(
                         "✓ {} alarm {instance}: Code={}, Name={}",
-                        alarm_type,
-                        alarm.code,
-                        alarm.get_name_with_encoding(TextEncoding::ShiftJis)
+                        alarm_type, alarm.code, alarm.name
                     );
                     info!("  Full alarm data for instance {instance}: {alarm:?}");
                 } else {

--- a/moto-hses-client/examples/connection_management.rs
+++ b/moto-hses-client/examples/connection_management.rs
@@ -36,6 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         retry_count: 3,
         retry_delay: Duration::from_millis(100),
         buffer_size: 8192,
+        text_encoding: moto_hses_proto::TextEncoding::ShiftJis,
     };
 
     // Attempt to connect with error handling
@@ -101,6 +102,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         retry_count: 1,
         retry_delay: Duration::from_millis(50),
         buffer_size: 8192,
+        text_encoding: moto_hses_proto::TextEncoding::ShiftJis,
     };
 
     match HsesClient::new_with_config(invalid_config).await {

--- a/moto-hses-client/examples/io_operations.rs
+++ b/moto-hses-client/examples/io_operations.rs
@@ -19,6 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         retry_count: 3,
         retry_delay: Duration::from_millis(100),
         buffer_size: 8192,
+        text_encoding: moto_hses_proto::TextEncoding::ShiftJis,
     };
 
     // Create client

--- a/moto-hses-client/examples/position_operations.rs
+++ b/moto-hses-client/examples/position_operations.rs
@@ -35,6 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         retry_count: 5,
         retry_delay: Duration::from_millis(200),
         buffer_size: 8192,
+        text_encoding: moto_hses_proto::TextEncoding::ShiftJis,
     };
 
     // Connect to the controller

--- a/moto-hses-client/examples/variable_operations.rs
+++ b/moto-hses-client/examples/variable_operations.rs
@@ -35,6 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         retry_count: 5,
         retry_delay: Duration::from_millis(200),
         buffer_size: 8192,
+        text_encoding: moto_hses_proto::TextEncoding::ShiftJis,
     };
 
     // Connect to the controller

--- a/moto-hses-client/src/types.rs
+++ b/moto-hses-client/src/types.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::net::UdpSocket;
 
-use moto_hses_proto::ProtocolError;
+use moto_hses_proto::{ProtocolError, TextEncoding};
 
 /// Client configuration options
 #[derive(Debug, Clone)]
@@ -20,6 +20,8 @@ pub struct ClientConfig {
     pub retry_count: u32,
     pub retry_delay: Duration,
     pub buffer_size: usize,
+    /// Text encoding used by the server (default: UTF-8)
+    pub text_encoding: TextEncoding,
 }
 
 impl Default for ClientConfig {
@@ -31,6 +33,7 @@ impl Default for ClientConfig {
             retry_count: 3,
             retry_delay: Duration::from_millis(100),
             buffer_size: 8192,
+            text_encoding: TextEncoding::Utf8,
         }
     }
 }

--- a/moto-hses-client/tests/common/test_utils.rs
+++ b/moto-hses-client/tests/common/test_utils.rs
@@ -41,6 +41,7 @@ pub async fn create_test_client_with_host_and_port(
         retry_count: 3,
         retry_delay: Duration::from_millis(100),
         buffer_size: 8192,
+        text_encoding: moto_hses_proto::TextEncoding::Utf8,
     };
 
     let client = HsesClient::new_with_config(config).await?;

--- a/moto-hses-client/tests/integration/alarm_operations.rs
+++ b/moto-hses-client/tests/integration/alarm_operations.rs
@@ -27,7 +27,7 @@ test_with_logging!(test_complete_alarm_data, {
         alarm_data.data,
         alarm_data.alarm_type,
         alarm_data.time,
-        alarm_data.get_name()
+        alarm_data.name
     );
 
     // Verify alarm data matches expected values from MockServer default state
@@ -37,7 +37,7 @@ test_with_logging!(test_complete_alarm_data, {
     assert_eq!(alarm_data.data, 1, "Alarm data should match expected value");
     assert_eq!(alarm_data.alarm_type, 1, "Alarm type should match expected value");
     assert_eq!(alarm_data.time, "2024/01/01 12:00", "Alarm time should match expected value");
-    assert_eq!(alarm_data.get_name(), "Servo Error", "Alarm name should match expected value");
+    assert_eq!(alarm_data.name, "Servo Error", "Alarm name should match expected value");
 
     log::info!("All alarm data values match expected values from MockServer");
     log::info!("Test completed successfully");
@@ -91,8 +91,8 @@ test_with_logging!(test_specific_alarm_attributes, {
         .read_alarm_data(1, AlarmAttribute::Name as u8)
         .await
         .expect("Failed to read alarm name");
-    log::info!("Alarm name: {}", alarm_name.get_name());
-    assert_eq!(alarm_name.get_name(), "Servo Error", "Alarm name should match expected value");
+    log::info!("Alarm name: {}", alarm_name.name);
+    assert_eq!(alarm_name.name, "Servo Error", "Alarm name should match expected value");
 
     log::info!("All specific alarm attributes match expected values");
 });
@@ -129,7 +129,7 @@ test_with_logging!(test_alarm_instances, {
             "Alarm instance {}: Code={}, Name={}",
             instance,
             alarm_instance.code,
-            alarm_instance.get_name()
+            alarm_instance.name
         );
 
         // Verify expected values
@@ -138,8 +138,7 @@ test_with_logging!(test_alarm_instances, {
             "Alarm instance {instance} code should match expected value {expected_code}"
         );
         assert_eq!(
-            alarm_instance.get_name(),
-            expected_name,
+            alarm_instance.name, expected_name,
             "Alarm instance {instance} name should match expected value '{expected_name}'"
         );
     }
@@ -181,7 +180,7 @@ test_with_logging!(test_alarm_history_major_failure, {
             "Major failure alarm {}: Code={}, Name={}",
             instance,
             alarm_history_code.code,
-            alarm_history_name.get_name()
+            alarm_history_name.name
         );
 
         // Verify expected values
@@ -190,8 +189,7 @@ test_with_logging!(test_alarm_history_major_failure, {
             "Major failure alarm {instance} code should match expected value {expected_code}"
         );
         assert_eq!(
-            alarm_history_name.get_name(),
-            expected_name,
+            alarm_history_name.name, expected_name,
             "Major failure alarm {instance} name should match expected value '{expected_name}'"
         );
     }
@@ -223,7 +221,7 @@ test_with_logging!(test_alarm_history_monitor, {
                 "Monitor alarm {}: Code={}, Name={}",
                 instance,
                 alarm_history.code,
-                alarm_history.get_name()
+                alarm_history.name
             );
             // If there's an alarm, verify it has valid data
             assert!(
@@ -231,7 +229,7 @@ test_with_logging!(test_alarm_history_monitor, {
                 "Monitor alarm {instance} should have positive code if not 'No alarm'"
             );
             assert!(
-                !alarm_history.get_name().is_empty(),
+                !alarm_history.name.is_empty(),
                 "Monitor alarm {instance} should have non-empty name if not 'No alarm'"
             );
         } else {

--- a/moto-hses-client/tests/integration/connection_management.rs
+++ b/moto-hses-client/tests/integration/connection_management.rs
@@ -119,6 +119,7 @@ test_with_logging!(test_retry_mechanism_actual, {
         retry_count: 3,
         retry_delay: std::time::Duration::from_millis(25),
         buffer_size: 8192,
+        text_encoding: moto_hses_proto::TextEncoding::Utf8,
     };
 
     let client = moto_hses_client::HsesClient::new_with_config(config)

--- a/moto-hses-mock/src/handlers/job.rs
+++ b/moto-hses-mock/src/handlers/job.rs
@@ -36,8 +36,8 @@ impl CommandHandler for ExecutingJobInfoHandler {
         };
 
         match service {
-            0x0e => job_info.serialize(attribute),
-            0x01 => job_info.serialize_complete(),
+            0x0e => job_info.serialize(attribute, state.text_encoding),
+            0x01 => job_info.serialize_complete(state.text_encoding),
             _ => Err(proto::ProtocolError::InvalidService),
         }
     }
@@ -101,7 +101,9 @@ impl CommandHandler for MovHandler {
                 // SetAll
                 if message.payload.len() >= 104 {
                     // Parse position data and update state
-                    if let Ok(position) = proto::Position::deserialize(&message.payload[0..52]) {
+                    if let Ok(position) =
+                        proto::Position::deserialize(&message.payload[0..52], state.text_encoding)
+                    {
                         state.update_position(position);
                     }
                 }
@@ -130,7 +132,9 @@ impl CommandHandler for PmovHandler {
                 // SetAll
                 if message.payload.len() >= 88 {
                     // Parse position data and update state
-                    if let Ok(position) = proto::Position::deserialize(&message.payload[0..52]) {
+                    if let Ok(position) =
+                        proto::Position::deserialize(&message.payload[0..52], state.text_encoding)
+                    {
                         state.update_position(position);
                     }
                 }

--- a/moto-hses-mock/src/handlers/position.rs
+++ b/moto-hses-mock/src/handlers/position.rs
@@ -36,7 +36,8 @@ impl CommandHandler for PositionVarHandler {
             0x02 => {
                 // SetAll
                 if message.payload.len() >= 52
-                    && let Ok(position) = proto::Position::deserialize(&message.payload)
+                    && let Ok(position) =
+                        proto::Position::deserialize(&message.payload, state.text_encoding)
                 {
                     state.update_position(position);
                 }
@@ -49,7 +50,8 @@ impl CommandHandler for PositionVarHandler {
             0x10 => {
                 // Write
                 if message.payload.len() >= 52
-                    && let Ok(position) = proto::Position::deserialize(&message.payload)
+                    && let Ok(position) =
+                        proto::Position::deserialize(&message.payload, state.text_encoding)
                 {
                     state.update_position(position);
                 }
@@ -82,7 +84,7 @@ impl CommandHandler for BasePositionVarHandler {
                     // Parse base position data
                     let mut data = vec![0u8; 52];
                     data[0..36].copy_from_slice(&message.payload[0..36]);
-                    if let Ok(position) = proto::Position::deserialize(&data) {
+                    if let Ok(position) = proto::Position::deserialize(&data, state.text_encoding) {
                         state.update_position(position);
                     }
                 }
@@ -95,7 +97,8 @@ impl CommandHandler for BasePositionVarHandler {
             0x10 => {
                 // Write
                 if message.payload.len() >= 52
-                    && let Ok(position) = proto::Position::deserialize(&message.payload)
+                    && let Ok(position) =
+                        proto::Position::deserialize(&message.payload, state.text_encoding)
                 {
                     state.update_position(position);
                 }
@@ -128,7 +131,7 @@ impl CommandHandler for ExternalAxisVarHandler {
                     // Parse external axis data
                     let mut data = vec![0u8; 52];
                     data[0..36].copy_from_slice(&message.payload[0..36]);
-                    if let Ok(position) = proto::Position::deserialize(&data) {
+                    if let Ok(position) = proto::Position::deserialize(&data, state.text_encoding) {
                         state.update_position(position);
                     }
                 }
@@ -141,7 +144,8 @@ impl CommandHandler for ExternalAxisVarHandler {
             0x10 => {
                 // Write
                 if message.payload.len() >= 52
-                    && let Ok(position) = proto::Position::deserialize(&message.payload)
+                    && let Ok(position) =
+                        proto::Position::deserialize(&message.payload, state.text_encoding)
                 {
                     state.update_position(position);
                 }

--- a/moto-hses-mock/src/handlers/system.rs
+++ b/moto-hses-mock/src/handlers/system.rs
@@ -17,9 +17,9 @@ impl CommandHandler for StatusHandler {
 
         let attribute = message.sub_header.attribute;
         let mut data = match attribute {
-            1 => state.status.data1.serialize()?,
-            2 => state.status.data2.serialize()?,
-            _ => state.status.serialize()?, // Default to complete status
+            1 => state.status.data1.serialize(state.text_encoding)?,
+            2 => state.status.data2.serialize(state.text_encoding)?,
+            _ => state.status.serialize(state.text_encoding)?, // Default to complete status
         };
 
         // Extend to 8 bytes if needed
@@ -38,7 +38,7 @@ impl CommandHandler for AxisNameHandler {
     fn handle(
         &self,
         _message: &proto::HsesRequestMessage,
-        _state: &mut MockState,
+        state: &mut MockState,
     ) -> Result<Vec<u8>, proto::ProtocolError> {
         let mut data = vec![0u8; 56]; // 7 axes * 8 bytes each
 
@@ -47,7 +47,8 @@ impl CommandHandler for AxisNameHandler {
             ["1st_axis", "2nd_axis", "3rd_axis", "4th_axis", "5th_axis", "6th_axis", "7th_axis"];
 
         for (i, name) in axis_names.iter().enumerate() {
-            let name_bytes = name.as_bytes();
+            let name_bytes =
+                moto_hses_proto::encoding_utils::encode_string(name, state.text_encoding);
             let start = i * 8;
             let len = name_bytes.len().min(7);
             data[start..start + len].copy_from_slice(&name_bytes[0..len]);
@@ -87,7 +88,7 @@ impl CommandHandler for ManagementTimeHandler {
     fn handle(
         &self,
         _message: &proto::HsesRequestMessage,
-        _state: &mut MockState,
+        state: &mut MockState,
     ) -> Result<Vec<u8>, proto::ProtocolError> {
         let mut data = vec![0u8; 32];
 
@@ -96,12 +97,14 @@ impl CommandHandler for ManagementTimeHandler {
         let elapse_time = "987654321";
 
         // Copy start time (16 bytes)
-        let start_bytes = start_time.as_bytes();
+        let start_bytes =
+            moto_hses_proto::encoding_utils::encode_string(start_time, state.text_encoding);
         let start_len = start_bytes.len().min(15);
         data[0..start_len].copy_from_slice(&start_bytes[0..start_len]);
 
         // Copy elapse time (16 bytes)
-        let elapse_bytes = elapse_time.as_bytes();
+        let elapse_bytes =
+            moto_hses_proto::encoding_utils::encode_string(elapse_time, state.text_encoding);
         let elapse_len = elapse_bytes.len().min(15);
         data[16..16 + elapse_len].copy_from_slice(&elapse_bytes[0..elapse_len]);
 
@@ -116,25 +119,28 @@ impl CommandHandler for SystemInfoHandler {
     fn handle(
         &self,
         _message: &proto::HsesRequestMessage,
-        _state: &mut MockState,
+        state: &mut MockState,
     ) -> Result<Vec<u8>, proto::ProtocolError> {
         let mut data = vec![0u8; 48];
 
         // Software version (16 bytes)
         let version = "V1.0.0";
-        let version_bytes = version.as_bytes();
+        let version_bytes =
+            moto_hses_proto::encoding_utils::encode_string(version, state.text_encoding);
         let len = version_bytes.len().min(15);
         data[0..len].copy_from_slice(&version_bytes[0..len]);
 
         // Model (16 bytes)
         let model = "FS100";
-        let model_bytes = model.as_bytes();
+        let model_bytes =
+            moto_hses_proto::encoding_utils::encode_string(model, state.text_encoding);
         let len = model_bytes.len().min(15);
         data[16..16 + len].copy_from_slice(&model_bytes[0..len]);
 
         // Parameter version (16 bytes)
         let param_version = "P1.0.0";
-        let param_version_bytes = param_version.as_bytes();
+        let param_version_bytes =
+            moto_hses_proto::encoding_utils::encode_string(param_version, state.text_encoding);
         let len = param_version_bytes.len().min(15);
         data[32..32 + len].copy_from_slice(&param_version_bytes[0..len]);
 

--- a/moto-hses-mock/src/lib.rs
+++ b/moto-hses-mock/src/lib.rs
@@ -21,6 +21,7 @@ pub struct MockConfig {
     pub host: String,
     pub robot_port: u16,
     pub file_port: u16,
+    pub text_encoding: proto::TextEncoding,
     pub default_status: proto::Status,
     pub default_position: proto::Position,
     pub registers: HashMap<u16, i16>,
@@ -54,6 +55,7 @@ impl MockConfig {
             host: host.into(),
             robot_port,
             file_port,
+            text_encoding: proto::TextEncoding::Utf8,
             default_status: proto::Status::new(
                 proto::StatusData1 {
                     step: false,

--- a/moto-hses-mock/src/server.rs
+++ b/moto-hses-mock/src/server.rs
@@ -31,6 +31,7 @@ impl MockServer {
         let file_socket = Arc::new(UdpSocket::bind(file_addr).await?);
 
         let mut mock_state = MockState {
+            text_encoding: config.text_encoding,
             status: config.default_status.clone(),
             position: config.default_position.clone(),
             registers: config.registers.clone(),
@@ -380,6 +381,12 @@ impl MockServerBuilder {
     #[must_use]
     pub const fn file_port(mut self, port: u16) -> Self {
         self.config.file_port = port;
+        self
+    }
+
+    #[must_use]
+    pub const fn text_encoding(mut self, encoding: proto::TextEncoding) -> Self {
+        self.config.text_encoding = encoding;
         self
     }
 

--- a/moto-hses-mock/src/state.rs
+++ b/moto-hses-mock/src/state.rs
@@ -8,6 +8,7 @@ use tokio::sync::RwLock;
 /// Mock server state
 #[derive(Debug, Clone)]
 pub struct MockState {
+    pub text_encoding: proto::TextEncoding,
     pub status: proto::Status,
     pub position: proto::Position,
     pub variables: HashMap<u8, Vec<u8>>,
@@ -145,6 +146,7 @@ impl Default for MockState {
         );
 
         Self {
+            text_encoding: proto::TextEncoding::Utf8,
             status: proto::Status::new(
                 proto::StatusData1 {
                     step: false,

--- a/moto-hses-proto/src/encoding_utils.rs
+++ b/moto-hses-proto/src/encoding_utils.rs
@@ -1,0 +1,134 @@
+//! Text encoding utilities
+
+use crate::encoding::TextEncoding;
+
+/// Decode bytes to string with specified encoding, with UTF-8 fallback on error
+///
+/// # Arguments
+/// * `bytes` - The byte slice to decode
+/// * `encoding` - The text encoding to use for decoding
+///
+/// # Returns
+/// The decoded string. If the specified encoding fails, falls back to UTF-8 lossy decoding.
+#[must_use]
+pub fn decode_string_with_fallback(bytes: &[u8], encoding: TextEncoding) -> String {
+    let (decoded, _encoding_used, had_errors) = encoding.to_encoding().decode(bytes);
+
+    if had_errors {
+        // If specified encoding decoding had errors, fallback to UTF-8
+        String::from_utf8_lossy(bytes).to_string()
+    } else {
+        decoded.to_string()
+    }
+}
+
+/// Encode string to bytes with specified encoding
+///
+/// # Arguments
+/// * `string` - The string to encode
+/// * `encoding` - The text encoding to use for encoding
+///
+/// # Returns
+/// The encoded bytes
+#[must_use]
+pub fn encode_string(string: &str, encoding: TextEncoding) -> Vec<u8> {
+    let (encoded, _encoding_used, _had_errors) = encoding.to_encoding().encode(string);
+    encoded.to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_string_with_fallback_utf8() {
+        let bytes = b"Hello World";
+        let result = decode_string_with_fallback(bytes, TextEncoding::Utf8);
+        assert_eq!(result, "Hello World");
+    }
+
+    #[test]
+    fn test_decode_string_with_fallback_shift_jis() {
+        let bytes = b"Hello World"; // ASCII characters work with both encodings
+        let result = decode_string_with_fallback(bytes, TextEncoding::ShiftJis);
+        assert_eq!(result, "Hello World");
+    }
+
+    #[test]
+    fn test_decode_string_with_fallback_shift_jis_japanese() {
+        // "テスト" in Shift_JIS encoding
+        let bytes = &[0x83, 0x65, 0x83, 0x58, 0x83, 0x67];
+        let result = decode_string_with_fallback(bytes, TextEncoding::ShiftJis);
+        assert_eq!(result, "テスト");
+    }
+
+    #[test]
+    fn test_decode_string_with_fallback_shift_jis_mixed() {
+        // "HelloテストWorld" in Shift_JIS encoding
+        let bytes = &[
+            0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x83, 0x65, 0x83, 0x58, 0x83, 0x67, 0x57, 0x6F, 0x72,
+            0x6C, 0x64,
+        ];
+        let result = decode_string_with_fallback(bytes, TextEncoding::ShiftJis);
+        assert_eq!(result, "HelloテストWorld");
+    }
+
+    #[test]
+    fn test_decode_string_with_fallback_invalid_utf8() {
+        let bytes = &[0xFF, 0xFE]; // Invalid UTF-8
+        let result = decode_string_with_fallback(bytes, TextEncoding::Utf8);
+        assert_eq!(result, ""); // UTF-8 lossy fallback
+    }
+
+    #[test]
+    fn test_encode_string_utf8() {
+        let string = "Hello World";
+        let result = encode_string(string, TextEncoding::Utf8);
+        assert_eq!(result, b"Hello World");
+    }
+
+    #[test]
+    fn test_encode_string_shift_jis() {
+        let string = "Hello World"; // ASCII characters work with both encodings
+        let result = encode_string(string, TextEncoding::ShiftJis);
+        assert_eq!(result, b"Hello World");
+    }
+
+    #[test]
+    fn test_encode_string_shift_jis_japanese() {
+        let string = "テスト";
+        let result = encode_string(string, TextEncoding::ShiftJis);
+        // "テスト" in Shift_JIS encoding
+        assert_eq!(result, &[0x83, 0x65, 0x83, 0x58, 0x83, 0x67]);
+    }
+
+    #[test]
+    fn test_encode_string_shift_jis_mixed() {
+        let string = "HelloテストWorld";
+        let result = encode_string(string, TextEncoding::ShiftJis);
+        // "HelloテストWorld" in Shift_JIS encoding
+        assert_eq!(
+            result,
+            &[
+                0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x83, 0x65, 0x83, 0x58, 0x83, 0x67, 0x57, 0x6F, 0x72,
+                0x6C, 0x64
+            ]
+        );
+    }
+
+    #[test]
+    fn test_roundtrip_shift_jis_japanese() {
+        let original = "テストアラーム";
+        let encoded = encode_string(original, TextEncoding::ShiftJis);
+        let decoded = decode_string_with_fallback(&encoded, TextEncoding::ShiftJis);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_roundtrip_shift_jis_mixed() {
+        let original = "HelloテストWorld123";
+        let encoded = encode_string(original, TextEncoding::ShiftJis);
+        let decoded = decode_string_with_fallback(&encoded, TextEncoding::ShiftJis);
+        assert_eq!(decoded, original);
+    }
+}

--- a/moto-hses-proto/src/lib.rs
+++ b/moto-hses-proto/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod alarm;
 pub mod encoding;
+pub mod encoding_utils;
 pub mod error;
 pub mod file;
 pub mod job;

--- a/moto-hses-proto/src/position.rs
+++ b/moto-hses-proto/src/position.rs
@@ -99,7 +99,10 @@ impl Position {
     /// # Errors
     /// Returns `ProtocolError::Underflow` if data is insufficient
     /// Returns `ProtocolError::PositionError` if data format is invalid
-    pub fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
+    pub fn deserialize(
+        data: &[u8],
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
         if data.len() < 52 {
             return Err(ProtocolError::Underflow);
         }
@@ -163,11 +166,17 @@ impl VariableType for Position {
     fn command_id() -> u16 {
         0x7f
     }
-    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+    fn serialize(
+        &self,
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Vec<u8>, ProtocolError> {
         self.serialize()
     }
-    fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
-        Self::deserialize(data)
+    fn deserialize(
+        data: &[u8],
+        encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
+        Self::deserialize(data, encoding)
     }
 }
 
@@ -211,7 +220,8 @@ mod tests {
     fn test_position_serialization() {
         let position = Position::Pulse(PulsePosition::new([1000, 2000, 3000, 0, 0, 0, 0, 0], 1));
         let serialized = position.serialize().unwrap();
-        let deserialized = Position::deserialize(&serialized).unwrap();
+        let deserialized =
+            Position::deserialize(&serialized, crate::encoding::TextEncoding::Utf8).unwrap();
         assert_eq!(position, deserialized);
     }
 
@@ -230,7 +240,8 @@ mod tests {
             CoordinateSystem::Base,
         ));
         let serialized = position.serialize().unwrap();
-        let deserialized = Position::deserialize(&serialized).unwrap();
+        let deserialized =
+            Position::deserialize(&serialized, crate::encoding::TextEncoding::Utf8).unwrap();
         assert_eq!(position, deserialized);
     }
 
@@ -241,7 +252,8 @@ mod tests {
         assert_eq!(Position::command_id(), 0x7f);
 
         let serialized = position.serialize().unwrap();
-        let deserialized = Position::deserialize(&serialized).unwrap();
+        let deserialized =
+            Position::deserialize(&serialized, crate::encoding::TextEncoding::Utf8).unwrap();
         assert_eq!(position, deserialized);
     }
 }

--- a/moto-hses-proto/src/status.rs
+++ b/moto-hses-proto/src/status.rs
@@ -68,13 +68,19 @@ impl VariableType for Status {
     fn command_id() -> u16 {
         0x72
     }
-    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+    fn serialize(
+        &self,
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Vec<u8>, ProtocolError> {
         let mut data = Vec::new();
-        data.extend(self.data1.serialize()?);
-        data.extend(self.data2.serialize()?);
+        data.extend(self.data1.serialize(crate::encoding::TextEncoding::Utf8)?);
+        data.extend(self.data2.serialize(crate::encoding::TextEncoding::Utf8)?);
         Ok(data)
     }
-    fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
+    fn deserialize(
+        data: &[u8],
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
         Self::from_bytes(data)
     }
 }
@@ -162,7 +168,10 @@ impl VariableType for StatusData1 {
     fn command_id() -> u16 {
         0x72
     }
-    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+    fn serialize(
+        &self,
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Vec<u8>, ProtocolError> {
         let mut data = Vec::new();
         let mut status_word = 0u32;
 
@@ -194,7 +203,10 @@ impl VariableType for StatusData1 {
         data.extend_from_slice(&status_word.to_le_bytes());
         Ok(data)
     }
-    fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
+    fn deserialize(
+        data: &[u8],
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
         Self::from_bytes(data)
     }
 }
@@ -203,7 +215,10 @@ impl VariableType for StatusData2 {
     fn command_id() -> u16 {
         0x72
     }
-    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+    fn serialize(
+        &self,
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Vec<u8>, ProtocolError> {
         let mut data = Vec::new();
         let mut status_word = 0u32;
 
@@ -229,7 +244,10 @@ impl VariableType for StatusData2 {
         data.extend_from_slice(&status_word.to_le_bytes());
         Ok(data)
     }
-    fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
+    fn deserialize(
+        data: &[u8],
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
         Self::from_bytes(data)
     }
 }
@@ -272,8 +290,9 @@ mod tests {
         };
         let status = Status::new(data1, data2);
 
-        let serialized = status.serialize().unwrap();
-        let deserialized = Status::deserialize(&serialized).unwrap();
+        let serialized = status.serialize(crate::encoding::TextEncoding::Utf8).unwrap();
+        let deserialized =
+            Status::deserialize(&serialized, crate::encoding::TextEncoding::Utf8).unwrap();
         assert_eq!(status.data1.step, deserialized.data1.step);
         assert_eq!(status.data2.servo_on, deserialized.data2.servo_on);
         assert_eq!(status.data1.running, deserialized.data1.running);
@@ -334,8 +353,9 @@ mod tests {
         };
         let status = Status::new(data1, data2);
 
-        let serialized = status.serialize().unwrap();
-        let deserialized = Status::deserialize(&serialized).unwrap();
+        let serialized = status.serialize(crate::encoding::TextEncoding::Utf8).unwrap();
+        let deserialized =
+            Status::deserialize(&serialized, crate::encoding::TextEncoding::Utf8).unwrap();
         assert_eq!(status.data1.step, deserialized.data1.step);
     }
 
@@ -348,8 +368,9 @@ mod tests {
         assert!(!status_data1.running);
         assert!(!status_data1.teach);
 
-        let serialized = status_data1.serialize().unwrap();
-        let deserialized = StatusData1::deserialize(&serialized).unwrap();
+        let serialized = status_data1.serialize(crate::encoding::TextEncoding::Utf8).unwrap();
+        let deserialized =
+            StatusData1::deserialize(&serialized, crate::encoding::TextEncoding::Utf8).unwrap();
         assert_eq!(status_data1.step, deserialized.step);
     }
 
@@ -362,8 +383,9 @@ mod tests {
         assert!(!status_data2.alarm);
         assert!(!status_data2.error);
 
-        let serialized = status_data2.serialize().unwrap();
-        let deserialized = StatusData2::deserialize(&serialized).unwrap();
+        let serialized = status_data2.serialize(crate::encoding::TextEncoding::Utf8).unwrap();
+        let deserialized =
+            StatusData2::deserialize(&serialized, crate::encoding::TextEncoding::Utf8).unwrap();
         assert_eq!(status_data2.servo_on, deserialized.servo_on);
     }
 }

--- a/moto-hses-proto/src/variables.rs
+++ b/moto-hses-proto/src/variables.rs
@@ -9,12 +9,18 @@ impl VariableType for u8 {
     fn command_id() -> u16 {
         0x7a
     }
-    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+    fn serialize(
+        &self,
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Vec<u8>, ProtocolError> {
         let mut data = vec![0u8; 4];
         data[0] = *self;
         Ok(data)
     }
-    fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
+    fn deserialize(
+        data: &[u8],
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
         if data.len() < 4 {
             return Err(ProtocolError::Underflow);
         }
@@ -26,13 +32,19 @@ impl VariableType for i16 {
     fn command_id() -> u16 {
         0x7b
     }
-    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+    fn serialize(
+        &self,
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Vec<u8>, ProtocolError> {
         // Protocol specification: 4 bytes (Byte 0-1: I variable, Byte 2-3: Reserved)
         let mut data = vec![0u8; 4];
         data[0..2].copy_from_slice(&self.to_le_bytes());
         Ok(data)
     }
-    fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
+    fn deserialize(
+        data: &[u8],
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
         if data.len() < 4 {
             return Err(ProtocolError::Underflow);
         }
@@ -46,10 +58,16 @@ impl VariableType for i32 {
     fn command_id() -> u16 {
         0x7c
     }
-    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+    fn serialize(
+        &self,
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Vec<u8>, ProtocolError> {
         Ok(self.to_le_bytes().to_vec())
     }
-    fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
+    fn deserialize(
+        data: &[u8],
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
         if data.len() < 4 {
             return Err(ProtocolError::Underflow);
         }
@@ -62,10 +80,16 @@ impl VariableType for f32 {
     fn command_id() -> u16 {
         0x7d
     }
-    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+    fn serialize(
+        &self,
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Vec<u8>, ProtocolError> {
         Ok(self.to_le_bytes().to_vec())
     }
-    fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
+    fn deserialize(
+        data: &[u8],
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
         if data.len() < 4 {
             return Err(ProtocolError::Underflow);
         }
@@ -79,7 +103,10 @@ impl VariableType for Vec<u8> {
         0x7e // String variable command
     }
 
-    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+    fn serialize(
+        &self,
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Vec<u8>, ProtocolError> {
         // S variables are 16 bytes (4 × 32-bit integers)
         // Pad with null bytes to 16 bytes
         let mut result = vec![0u8; 16];
@@ -88,7 +115,10 @@ impl VariableType for Vec<u8> {
         Ok(result)
     }
 
-    fn deserialize(data: &[u8]) -> Result<Self, ProtocolError> {
+    fn deserialize(
+        data: &[u8],
+        _encoding: crate::encoding::TextEncoding,
+    ) -> Result<Self, ProtocolError> {
         // S variables should be 16 bytes, but handle shorter responses gracefully
         // Always pad to 16 bytes first, then remove trailing nulls for consistent behavior
         let mut padded_data = [0u8; 16];


### PR DESCRIPTION
## Overview

This PR implements a comprehensive unified text encoding system that ensures all messages use the encoding configured at client initialization, providing consistent text handling across the entire protocol stack.

## Major Changes

- ✨ **Feature**: Add configurable text encoding to ClientConfig and MockConfig
- 🔧 **Improvement**: Unify deserialize/serialize methods to accept TextEncoding parameter
- 🏗️ **Refactor**: Change string fields from Vec<u8> to String in Alarm and other structs
- 🏗️ **Refactor**: Create encoding_utils module for centralized string conversion
- 🐛 **Fix**: Update all handlers to use configurable text encoding
- 🧪 **Test**: Add comprehensive tests for Shift_JIS encoding support
- 🔧 **Improvement**: Fix all Clippy warnings and improve code quality

## Technical Details

### Core Changes
- **ClientConfig**: Added  field
- **MockConfig/MockState**: Added  field
- **VariableType trait**: Updated  and  methods to accept  parameter
- **Alarm struct**: Changed string fields from  to  for direct access
- **encoding_utils module**: Centralized  and  functions

### API Improvements
- **Unified deserialization**: Single  method
- **Unified serialization**: Single  method
- **Direct field access**: String fields can be accessed directly without encoding-aware getters
- **Consistent encoding**: All string operations use the configured encoding

### Mock Server Enhancements
- **Configurable encoding**: Mock server can be initialized with any text encoding
- **Consistent behavior**: All handlers use the server's configured encoding
- **File operations**: File list and filename handling respects encoding settings
- **System information**: Axis names, management times, and system info use proper encoding

## Testing

- ✅ All unit tests pass
- ✅ Integration tests pass
- ✅ Clippy warnings resolved
- ✅ Shift_JIS encoding tests added
- ✅ Round-trip encoding tests implemented
- ✅ Mock server encoding configuration tests

## Breaking Changes

- **Alarm struct**: String fields changed from  to 
- **VariableType trait**: Method signatures updated to include  parameter
- **ClientConfig**: New required  field
- **MockConfig**: New required  field