### PR TITLE
fix: update controller IP address to 192.168.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use moto_hses_client::HsesClient;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create client
-    let client = HsesClient::new("192.168.1.100:10040").await?;
+    let client = HsesClient::new("192.168.0.3:10040").await?;
 
     // Read alarm data
     let alarm = client.read_alarm_data(1, 0).await?;
@@ -77,7 +77,7 @@ Comprehensive examples are available in the [`examples/`](moto-hses-client/examp
 
 ```bash
 # Run a specific example
-RUST_LOG=info cargo run -p moto-hses-client --example alarm_operations -- 192.168.1.100 10040
+RUST_LOG=info cargo run -p moto-hses-client --example alarm_operations -- 192.168.0.3 10040
 ```
 
 ### Mock Server Testing

--- a/moto-hses-client/README.md
+++ b/moto-hses-client/README.md
@@ -36,7 +36,7 @@ use moto_hses_client::HsesClient;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create client
-    let client = HsesClient::new("192.168.1.100:10040").await?;
+    let client = HsesClient::new("192.168.0.3:10040").await?;
 
     // Read alarm data
     let alarm = client.read_alarm_data(1, 0).await?;
@@ -96,7 +96,7 @@ The crate includes comprehensive examples in the `examples/` directory:
 
 ```bash
 # Run a specific example
-RUST_LOG=info cargo run --example alarm_operations -- 192.168.1.100 10040
+RUST_LOG=info cargo run --example alarm_operations -- 192.168.0.3 10040
 ```
 
 ## Testing

--- a/moto-hses-mock/README.md
+++ b/moto-hses-mock/README.md
@@ -38,7 +38,7 @@ use moto_hses_proto::Alarm;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start mock server with custom configuration using builder pattern
     let server = MockServerBuilder::new()
-        .host("192.168.1.100")
+        .host("192.168.0.3")
         .robot_port(20000)
         .file_port(20001)
         .with_alarm(Alarm::new(1001, 0, 0, "2024-01-01 12:00:00".to_string(), "Test alarm".to_string()))
@@ -96,7 +96,7 @@ The crate includes examples demonstrating various usage patterns:
 cargo run --example mock_basic_usage
 
 # Run with custom address and port
-cargo run --example mock_basic_usage -- 192.168.1.100 10040 10041
+cargo run --example mock_basic_usage -- 192.168.0.3 10040 10041
 ```
 
 ## License

--- a/moto-hses-mock/src/bin/server.rs
+++ b/moto-hses-mock/src/bin/server.rs
@@ -2,7 +2,7 @@
 //! Usage: cargo run -p moto-hses-mock -- \[host\] \[`robot_port`\] \[`file_port`\]
 //! Examples:
 //!   cargo run -p moto-hses-mock                    # Default: 127.0.0.1:10040, 127.0.0.1:10041
-//!   cargo run -p moto-hses-mock -- 192.168.1.100 10040 10041
+//!   cargo run -p moto-hses-mock -- 192.168.0.3 10040 10041
 //!   cargo run -p moto-hses-mock -- 127.0.0.1 20000 20001
 
 use log::info;


### PR DESCRIPTION
## Overview

Update controller IP address examples in README files and mock server from 192.168.1.100 to 192.168.0.3 to match the actual verification environment.

## Changes

- README.md: Updated basic usage example and command examples
- moto-hses-client/README.md: Updated client examples
- moto-hses-mock/README.md: Updated mock server examples  
- moto-hses-mock/src/bin/server.rs: Updated usage comment

## Impact

This is a documentation-only change with no functional impact on the codebase.