### PR TITLE
feat: implement 0x84 cycle mode switching command

### DIFF
--- a/docs/design/protocol-commands.md
+++ b/docs/design/protocol-commands.md
@@ -32,7 +32,7 @@ This API is designed based on the following HSES protocol commands:
 | `read_variable<ExternalAxis>()`, `write_variable()`               | 0x81       | External axis type variable (EX) reading / writing command                  |
 | `reset_alarm()`                                                   | 0x82       | Alarm reset / error cancel command                                          |
 | `set_hold()`, `set_servo()`                                       | 0x83       | HOLD / servo ON/OFF command                                                 |
-| `set_execution_mode()`                                            | 0x84       | Step / cycle / continuous switching command                                 |
+| `set_cycle_mode()`                                            | 0x84       | Step / cycle / continuous switching command                                 |
 | `display_message()`                                               | 0x85       | Character string display command to the programming pendant                 |
 | `start_job()`                                                     | 0x86       | Start-up (job START) command                                                |
 | `select_job()`                                                    | 0x87       | Job select command                                                          |

--- a/docs/implementation-plans/0x84-cycle-mode-switching-command.md
+++ b/docs/implementation-plans/0x84-cycle-mode-switching-command.md
@@ -45,7 +45,7 @@ Payload: None
 
 ### 1. Protocol Layer Implementation
 
-**File**: `moto-hses-proto/src/cycle.rs`
+**File**: `moto-hses-proto/src/cycle_mode.rs`
 
 ```rust
 // Cycle mode switching command (0x84)
@@ -97,12 +97,12 @@ impl MockState {
 
 ### 3. Mock Server Handler
 
-**File**: `moto-hses-mock/src/handlers/cycle-switching.rs`
+**File**: `moto-hses-mock/src/handlers/cycle_mode_switching.rs`
 
 ```rust
-pub struct CycleSwitchingHandler;
+pub struct CycleModeSwitchingHandler;
 
-impl CommandHandler for CycleSwitchingHandler {
+impl CommandHandler for CycleModeSwitchingHandler {
     fn handle(&self, message: &HsesRequestMessage, state: &mut MockState) -> Result<Vec<u8>, ProtocolError> {
         // Validate instance=2, attribute=1, service=0x10
         // Parse 4-byte payload to get cycle mode
@@ -133,20 +133,22 @@ impl HsesClient {
 
 ```rust
 // Register 0x84 cycle mode switching handler
-registry.insert(0x84, Box::new(CycleSwitchingHandler));
+registry.insert(0x84, Box::new(CycleModeSwitchingHandler));
 ```
 
 ## Implementation Order
 
-1. **Protocol Layer** (`moto-hses-proto/src/cycle.rs`)
+1. **Protocol Layer** (`moto-hses-proto/src/cycle_mode.rs`)
 2. **Client API** (`moto-hses-client/src/protocol.rs`)
 3. **MockState Extension** (add cycle_mode field)
-4. **Handler Implementation** (`moto-hses-mock/src/handlers/cycle-switching.rs`)
+4. **Handler Implementation** (`moto-hses-mock/src/handlers/cycle_mode_switching.rs`)
 5. **Registry Registration**
 6. **Remove Old Handler** (SelectCycleHandler from job.rs)
 7. **Unit Tests**
 8. **Integration Tests** (`moto-hses-client/tests/integration/cycle_mode_control.rs`)
 9. **Example Code** (`moto-hses-client/examples/cycle_mode_control.rs`) - Extract from integration tests
+10. **Documentation Updates** (`moto-hses-client/README.md`) - Add new example and features
+11. **Quality Checks** - Run formatting, clippy, tests, and documentation checks
 
 ## Testing Strategy
 
@@ -174,6 +176,16 @@ registry.insert(0x84, Box::new(CycleSwitchingHandler));
 - **Pattern**: Simplified version of integration test scenarios
 - **Benefits**: Reuse tested code patterns, ensure examples work correctly
 
+### Documentation Updates
+
+- **File**: `moto-hses-client/README.md`
+- **Updates**:
+  - Add new example to examples list
+  - Add new feature to supported operations
+  - Add example execution command
+- **Pattern**: Follow existing documentation structure
+- **Benefits**: Keep documentation current and comprehensive
+
 ## Notes
 
 - Instance and Attribute are fixed values, so validation is critical
@@ -181,24 +193,105 @@ registry.insert(0x84, Box::new(CycleSwitchingHandler));
 - Response has no payload (status only)
 - MockState needs cycle_mode state management
 
+## Testing Considerations
+
+### MockServer State Verification Pattern
+
+For commands that modify MockServer state, integration tests should verify that the state changes correctly:
+
+1. **Direct State Access**: Use `Arc<MockServer>` to access server state directly
+2. **State Verification**: After each command, verify the expected state change
+3. **Pattern for Other Commands**: This pattern should be applied to other state-modifying commands
+
+```rust
+// Example pattern for state verification tests
+let server = Arc::new(MockServerBuilder::new()
+    .with_initial_state(initial_value)
+    .build().await?);
+
+let server_clone = Arc::clone(&server);
+let server_handle = tokio::spawn(async move {
+    server_clone.run().await?;
+});
+
+// Execute command
+client.execute_command().await?;
+wait_for_operation().await;
+
+// Verify state change
+let current_state = server.get_state().await;
+assert_eq!(current_state, expected_value);
+```
+
+### Applicable Commands
+
+This testing pattern should be considered for:
+- Commands that modify MockState fields
+- Commands without read-back capability in the protocol
+- Commands where state verification is critical for functionality
+
+## Quality Assurance
+
+### Pre-Push Quality Checks
+
+Before pushing code, run the following checks in order:
+
+1. **Code Formatting** (Fast check)
+   ```bash
+   cargo fmt --all -- --check
+   ```
+   - **When**: After each major implementation step
+   - **Fix**: `cargo fmt --all` if needed
+
+2. **Static Analysis** (Fast check)
+   ```bash
+   cargo clippy --all-targets --all-features -- -D warnings
+   ```
+   - **When**: After each implementation step
+   - **Fix**: Address all warnings before proceeding
+
+3. **Tests** (Slower check)
+   ```bash
+   cargo test --all-features --workspace
+   ```
+   - **When**: After unit tests and integration tests
+   - **Fix**: Ensure all tests pass
+
+4. **Documentation Build** (Slower check)
+   ```bash
+   cargo doc --all-features --no-deps
+   ```
+   - **When**: After documentation updates
+   - **Fix**: Address rustdoc warnings
+
+### Recommended Check Points
+
+- **After Step 1-6**: Run formatting and clippy checks
+- **After Step 7-8**: Run all tests
+- **After Step 10**: Run documentation build
+- **Before Push**: Run all quality checks
+
 ## Status
 
 - [x] Specification analysis
-- [ ] Protocol layer implementation
-- [ ] MockState extension
-- [ ] Handler implementation
-- [ ] Registry registration
-- [ ] Unit tests
-- [ ] Integration tests
+- [x] Protocol layer implementation
+- [x] MockState extension
+- [x] Handler implementation
+- [x] Registry registration
+- [x] Unit tests
+- [x] Integration tests
+- [x] Example code
+- [x] Documentation updates
 
 ## Related Files
 
-- `moto-hses-proto/src/cycle.rs` (new) - Contains `CycleModeSwitchingCommand`
+- `moto-hses-proto/src/cycle_mode.rs` (new) - Contains `CycleModeSwitchingCommand`
 - `moto-hses-client/src/protocol.rs` (modify) - Add client API methods
 - `moto-hses-client/examples/cycle_mode_control.rs` (new) - Example code
 - `moto-hses-client/tests/integration/cycle_mode_control.rs` (new) - Integration tests
 - `moto-hses-client/tests/integration/mod.rs` (modify) - Register test module
-- `moto-hses-mock/src/handlers/cycle-switching.rs` (new) - Contains `CycleSwitchingHandler`
+- `moto-hses-client/README.md` (modify) - Update documentation
+- `moto-hses-mock/src/handlers/cycle_mode_switching.rs` (new) - Contains `CycleModeSwitchingHandler`
 - `moto-hses-mock/src/state.rs` (modify) - Add cycle_mode field
 - `moto-hses-mock/src/handlers/registry.rs` (modify) - Update handler registration
 - `moto-hses-mock/src/handlers/job.rs` (modify) - Remove SelectCycleHandler

--- a/docs/implementation-plans/0x84-cycle-mode-switching-command.md
+++ b/docs/implementation-plans/0x84-cycle-mode-switching-command.md
@@ -1,0 +1,205 @@
+# 0x84 Cycle Mode Command Implementation Plan
+
+## Overview
+
+This document outlines the implementation plan for the 0x84 command (Step / Cycle / Continuous Switching Command) in the Moto-HSES Rust client library.
+
+## Command Specification
+
+### HSES Protocol Details
+
+- **Command ID**: 0x84
+- **Instance**: Fixed to 2
+- **Attribute**: Fixed to 1
+- **Service**: 0x10 (Set_Attribute_Single)
+- **Payload**: 4-byte 32-bit integer
+  - `1`: STEP
+  - `2`: ONE CYCLE
+  - `3`: CONTINUOUS
+- **Response**: Status only (no payload)
+
+### Request Structure
+
+```
+Command: 0x84
+Instance: 2 (fixed)
+Attribute: 1 (fixed)
+Service: 0x10 (Set_Attribute_Single)
+Payload: 4 bytes (32-bit integer)
+  - 1: STEP
+  - 2: ONE CYCLE
+  - 3: CONTINUOUS
+```
+
+### Response Structure
+
+```
+Status: Command execution result
+  - 0x00: Success
+  - Other: Error
+Added Status: Error code (if status is non-zero)
+Payload: None
+```
+
+## Implementation Plan
+
+### 1. Protocol Layer Implementation
+
+**File**: `moto-hses-proto/src/cycle.rs`
+
+```rust
+// Cycle mode switching command (0x84)
+#[derive(Debug, Clone)]
+pub struct CycleModeSwitchingCommand {
+    pub mode: CycleMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CycleMode {
+    Step = 1,
+    OneCycle = 2,
+    Continuous = 3,
+}
+
+impl Command for CycleModeSwitchingCommand {
+    type Response = ();
+    fn command_id() -> u16 { 0x84 }
+    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+        Ok(vec![self.mode as u8, 0, 0, 0])
+    }
+    fn instance(&self) -> u16 { 2 }
+    fn attribute(&self) -> u8 { 1 }
+    fn service(&self) -> u8 { 0x10 }
+}
+```
+
+### 2. MockState Extension
+
+**File**: `moto-hses-mock/src/state.rs`
+
+Add to `MockState` struct:
+```rust
+pub struct MockState {
+    // ... existing fields ...
+    pub cycle_mode: CycleMode,
+}
+
+impl MockState {
+    pub fn set_cycle_mode(&mut self, mode: CycleMode) {
+        self.cycle_mode = mode;
+    }
+    
+    pub fn get_cycle_mode(&self) -> CycleMode {
+        self.cycle_mode
+    }
+}
+```
+
+### 3. Mock Server Handler
+
+**File**: `moto-hses-mock/src/handlers/cycle-switching.rs`
+
+```rust
+pub struct CycleSwitchingHandler;
+
+impl CommandHandler for CycleSwitchingHandler {
+    fn handle(&self, message: &HsesRequestMessage, state: &mut MockState) -> Result<Vec<u8>, ProtocolError> {
+        // Validate instance=2, attribute=1, service=0x10
+        // Parse 4-byte payload to get cycle mode
+        // Update state with new cycle mode
+        // Return empty payload (success response)
+    }
+}
+```
+
+### 4. Client API Implementation
+
+**File**: `moto-hses-client/src/protocol.rs`
+
+```rust
+impl HsesClient {
+    /// Set cycle mode (0x84 command)
+    pub async fn set_cycle_mode(&self, mode: CycleMode) -> Result<(), ClientError> {
+        let command = CycleModeSwitchingCommand { mode };
+        let _response = self.send_command_with_retry(command, Division::Robot).await?;
+        Ok(())
+    }
+}
+```
+
+### 5. Handler Registry Registration
+
+**File**: `moto-hses-mock/src/handlers/registry.rs`
+
+```rust
+// Register 0x84 cycle mode switching handler
+registry.insert(0x84, Box::new(CycleSwitchingHandler));
+```
+
+## Implementation Order
+
+1. **Protocol Layer** (`moto-hses-proto/src/cycle.rs`)
+2. **Client API** (`moto-hses-client/src/protocol.rs`)
+3. **MockState Extension** (add cycle_mode field)
+4. **Handler Implementation** (`moto-hses-mock/src/handlers/cycle-switching.rs`)
+5. **Registry Registration**
+6. **Remove Old Handler** (SelectCycleHandler from job.rs)
+7. **Unit Tests**
+8. **Integration Tests** (`moto-hses-client/tests/integration/cycle_mode_control.rs`)
+9. **Example Code** (`moto-hses-client/examples/cycle_mode_control.rs`) - Extract from integration tests
+
+## Testing Strategy
+
+### Unit Tests
+
+- Command struct tests
+- Serialization/deserialization
+- Validation logic
+- Error handling
+
+### Integration Tests
+
+- **File**: `moto-hses-client/tests/integration/cycle_mode_control.rs`
+- **Test Cases**:
+  - All cycle modes (Step, OneCycle, Continuous)
+  - Error handling scenarios
+  - Mock server communication
+  - Various usage patterns and combinations
+- **Registration**: Add module to `mod.rs` and `integration_tests.rs`
+
+### Example Code
+
+- **File**: `moto-hses-client/examples/cycle_mode_control.rs`
+- **Content**: Extract common usage patterns from integration tests
+- **Pattern**: Simplified version of integration test scenarios
+- **Benefits**: Reuse tested code patterns, ensure examples work correctly
+
+## Notes
+
+- Instance and Attribute are fixed values, so validation is critical
+- Payload is only 4-byte 32-bit integer
+- Response has no payload (status only)
+- MockState needs cycle_mode state management
+
+## Status
+
+- [x] Specification analysis
+- [ ] Protocol layer implementation
+- [ ] MockState extension
+- [ ] Handler implementation
+- [ ] Registry registration
+- [ ] Unit tests
+- [ ] Integration tests
+
+## Related Files
+
+- `moto-hses-proto/src/cycle.rs` (new) - Contains `CycleModeSwitchingCommand`
+- `moto-hses-client/src/protocol.rs` (modify) - Add client API methods
+- `moto-hses-client/examples/cycle_mode_control.rs` (new) - Example code
+- `moto-hses-client/tests/integration/cycle_mode_control.rs` (new) - Integration tests
+- `moto-hses-client/tests/integration/mod.rs` (modify) - Register test module
+- `moto-hses-mock/src/handlers/cycle-switching.rs` (new) - Contains `CycleSwitchingHandler`
+- `moto-hses-mock/src/state.rs` (modify) - Add cycle_mode field
+- `moto-hses-mock/src/handlers/registry.rs` (modify) - Update handler registration
+- `moto-hses-mock/src/handlers/job.rs` (modify) - Remove SelectCycleHandler
+

--- a/docs/implementation-plans/README.md
+++ b/docs/implementation-plans/README.md
@@ -1,0 +1,38 @@
+# Implementation Plans
+
+This directory contains detailed implementation plans for HSES protocol commands and features.
+
+## Available Plans
+
+- [0x84 Cycle Mode Switching Command](./0x84-cycle-mode-switching-command.md) - Step / Cycle / Continuous Switching Command
+
+## Plan Structure
+
+Each implementation plan document follows a consistent structure:
+
+1. **Overview** - Brief description of the command/feature
+2. **Command Specification** - HSES protocol details
+3. **Implementation Plan** - Step-by-step implementation details
+4. **Implementation Order** - Recommended sequence
+5. **Testing Strategy** - Unit and integration test plans
+6. **Status** - Progress tracking
+7. **Related Files** - Files that will be created or modified
+
+## Usage
+
+These plans serve as:
+- Development roadmaps for implementing new commands
+- Reference documentation for understanding command specifications
+- Progress tracking for implementation status
+- Testing guidelines for validation
+
+## Contributing
+
+When creating new implementation plans:
+
+1. Follow the established document structure
+2. Include comprehensive command specifications
+3. Provide detailed implementation steps
+4. Include testing strategies
+5. Update this README with new plan references
+

--- a/docs/specs/hses-protocol.md
+++ b/docs/specs/hses-protocol.md
@@ -1204,14 +1204,14 @@ This data interlocks the P.P (Programming Pendant) and I/O operation system sign
 
 - **Command**: 0x84
 - **Instance**: Fixed to 2
-  - Details: Specifies the type of status switching command. `2`: CYCLE (STEP/CYCLE/CONTINUE switching)
 - **Attribute**: Fixed to 1
 - **Service**:
   - `0x10` (Set_Attribute_Single): Execute the specified request
 - **Payload**: Data exists during writing operation only
   - 32-bit integer (4 bytes): CYCLE specification
-    - Byte 0: Data 1
-    - CYCLE = 1: STEP / 2: CYCLE / 3: CONTINUE
+    - `1`: STEP
+    - `2`: ONE CYCLE
+    - `3`: CONTINUOUS
 
 **Response Structure:**
 

--- a/moto-hses-client/README.md
+++ b/moto-hses-client/README.md
@@ -78,11 +78,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - Joint position data
 - Position monitoring
 
+### Cycle Mode Control
+- Step mode switching
+- One cycle mode switching
+- Continuous mode switching
+
 ## Examples
 
 The crate includes comprehensive examples in the `examples/` directory:
 
 - `alarm_operations.rs` - Alarm data handling
+- `cycle_mode_control.rs` - Cycle mode switching operations
 - `io_operations.rs` - I/O operations
 - `position_operations.rs` - Position data operations
 - `variable_operations.rs` - Variable read/write operations
@@ -97,6 +103,7 @@ The crate includes comprehensive examples in the `examples/` directory:
 ```bash
 # Run a specific example
 RUST_LOG=info cargo run --example alarm_operations -- 192.168.0.3 10040
+
 ```
 
 ## Testing

--- a/moto-hses-client/examples/cycle_mode_control.rs
+++ b/moto-hses-client/examples/cycle_mode_control.rs
@@ -1,0 +1,70 @@
+use log::info;
+use moto_hses_client::HsesClient;
+use moto_hses_proto::{CycleMode, ROBOT_CONTROL_PORT};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    let args: Vec<String> = std::env::args().collect();
+
+    let (host, robot_port) = match args.as_slice() {
+        [_, host, robot_port] => {
+            // Format: [host] [robot_port]
+            let robot_port: u16 =
+                robot_port.parse().map_err(|_| format!("Invalid robot port: {robot_port}"))?;
+
+            (host.to_string(), robot_port)
+        }
+        _ => {
+            // Default: 127.0.0.1:DEFAULT_PORT
+            ("127.0.0.1".to_string(), ROBOT_CONTROL_PORT)
+        }
+    };
+
+    let controller_addr = format!("{host}:{robot_port}");
+    info!("Connecting to controller at {controller_addr}...");
+    let client = HsesClient::new(&controller_addr).await?;
+
+    info!("Successfully connected to controller");
+
+    info!("=== 0x84 Command (Cycle Mode Switching) Usage Example ===\n");
+
+    // 1. Test STEP mode
+    info!("1. Setting cycle mode to STEP:");
+    client.set_cycle_mode(CycleMode::Step).await?;
+    info!("✓ STEP mode command sent");
+
+    // 2. Test ONE CYCLE mode
+    info!("2. Setting cycle mode to ONE CYCLE:");
+    client.set_cycle_mode(CycleMode::OneCycle).await?;
+    info!("✓ ONE CYCLE mode command sent");
+
+    // 3. Test CONTINUOUS mode
+    info!("3. Setting cycle mode to CONTINUOUS:");
+    client.set_cycle_mode(CycleMode::Continuous).await?;
+    info!("✓ CONTINUOUS mode command sent");
+
+    // 4. Test mode sequence
+    info!("4. Testing mode sequence:");
+    let modes = [CycleMode::Step, CycleMode::OneCycle, CycleMode::Continuous];
+    for (i, mode) in modes.iter().enumerate() {
+        client.set_cycle_mode(*mode).await?;
+        info!("  {}. Set to {:?} mode", i + 1, mode);
+    }
+
+    // 5. Test rapid mode changes
+    info!("5. Testing rapid mode changes:");
+    for i in 0..3 {
+        client.set_cycle_mode(CycleMode::Step).await?;
+        client.set_cycle_mode(CycleMode::OneCycle).await?;
+        client.set_cycle_mode(CycleMode::Continuous).await?;
+        info!("  Cycle {} completed", i + 1);
+    }
+
+    info!("\n✓ All cycle mode operations completed successfully");
+    info!("Example usage:");
+    info!("  cargo run --example cycle_mode_control");
+    info!("  cargo run --example cycle_mode_control 192.168.1.100 10040");
+
+    Ok(())
+}

--- a/moto-hses-client/src/protocol.rs
+++ b/moto-hses-client/src/protocol.rs
@@ -188,6 +188,23 @@ impl HsesClient {
         Ok(())
     }
 
+    /// Set cycle mode (0x84 command)
+    ///
+    /// # Arguments
+    /// * `mode` - Cycle mode to set (Step, `OneCycle`, or Continuous)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if communication fails
+    pub async fn set_cycle_mode(
+        &self,
+        mode: moto_hses_proto::CycleMode,
+    ) -> Result<(), ClientError> {
+        let command = moto_hses_proto::CycleModeSwitchingCommand::new(mode);
+        let _response = self.send_command_with_retry(command, Division::Robot).await?;
+        Ok(())
+    }
+
     /// Read executing job information
     ///
     /// # Arguments

--- a/moto-hses-client/tests/integration/cycle_mode_control.rs
+++ b/moto-hses-client/tests/integration/cycle_mode_control.rs
@@ -1,0 +1,188 @@
+#![allow(clippy::expect_used)]
+// Integration tests for cycle mode control operations
+
+use crate::common::test_utils::{create_test_client, wait_for_operation};
+use crate::test_with_logging;
+use moto_hses_mock::server::MockServerBuilder;
+use moto_hses_proto::{CycleMode, FILE_CONTROL_PORT, ROBOT_CONTROL_PORT};
+use std::sync::Arc;
+
+test_with_logging!(test_cycle_mode_control_commands, {
+    // Create mock server with initial cycle mode
+    let server = Arc::new(
+        MockServerBuilder::new()
+            .host("127.0.0.1")
+            .robot_port(ROBOT_CONTROL_PORT)
+            .file_port(FILE_CONTROL_PORT)
+            .with_cycle_mode(CycleMode::Continuous)
+            .build()
+            .await
+            .expect("Failed to build mock server"),
+    );
+
+    // Start server in background
+    let server_clone = Arc::clone(&server);
+    let server_handle = tokio::spawn(async move {
+        server_clone.run().await.expect("Failed to run mock server");
+    });
+
+    // Wait for server to be ready
+    wait_for_operation().await;
+
+    let client = create_test_client().await.expect("Failed to create client");
+
+    // Verify initial state
+    let initial_mode = server.get_cycle_mode().await;
+    assert_eq!(initial_mode, CycleMode::Continuous);
+    log::info!("✓ Initial cycle mode: {initial_mode:?}");
+
+    // Test STEP mode
+    log::info!("Testing STEP mode...");
+    client.set_cycle_mode(CycleMode::Step).await.expect("Failed to set STEP mode");
+    wait_for_operation().await;
+
+    let current_mode = server.get_cycle_mode().await;
+    assert_eq!(current_mode, CycleMode::Step);
+    log::info!("✓ STEP mode verified: {current_mode:?}");
+
+    // Test ONE CYCLE mode
+    log::info!("Testing ONE CYCLE mode...");
+    client.set_cycle_mode(CycleMode::OneCycle).await.expect("Failed to set ONE CYCLE mode");
+    wait_for_operation().await;
+
+    let current_mode = server.get_cycle_mode().await;
+    assert_eq!(current_mode, CycleMode::OneCycle);
+    log::info!("✓ ONE CYCLE mode verified: {current_mode:?}");
+
+    // Test CONTINUOUS mode
+    log::info!("Testing CONTINUOUS mode...");
+    client.set_cycle_mode(CycleMode::Continuous).await.expect("Failed to set CONTINUOUS mode");
+    wait_for_operation().await;
+
+    let current_mode = server.get_cycle_mode().await;
+    assert_eq!(current_mode, CycleMode::Continuous);
+    log::info!("✓ CONTINUOUS mode verified: {current_mode:?}");
+
+    log::info!("✓ All cycle mode commands completed successfully");
+
+    // Clean up
+    server_handle.abort();
+});
+
+test_with_logging!(test_cycle_mode_sequence, {
+    // Create mock server with initial cycle mode
+    let server = Arc::new(
+        MockServerBuilder::new()
+            .host("127.0.0.1")
+            .robot_port(ROBOT_CONTROL_PORT)
+            .file_port(FILE_CONTROL_PORT)
+            .with_cycle_mode(CycleMode::Step)
+            .build()
+            .await
+            .expect("Failed to build mock server"),
+    );
+
+    // Start server in background
+    let server_clone = Arc::clone(&server);
+    let server_handle = tokio::spawn(async move {
+        server_clone.run().await.expect("Failed to run mock server");
+    });
+
+    // Wait for server to be ready
+    wait_for_operation().await;
+
+    let client = create_test_client().await.expect("Failed to create client");
+
+    // Test a sequence of mode changes
+    log::info!("Testing cycle mode sequence...");
+
+    // Verify initial state
+    let initial_mode = server.get_cycle_mode().await;
+    assert_eq!(initial_mode, CycleMode::Step);
+    log::info!("✓ Initial mode: {initial_mode:?}");
+
+    // Switch to CONTINUOUS
+    client.set_cycle_mode(CycleMode::Continuous).await.expect("Failed to set CONTINUOUS mode");
+    wait_for_operation().await;
+    assert_eq!(server.get_cycle_mode().await, CycleMode::Continuous);
+    log::info!("✓ Switched to CONTINUOUS mode");
+
+    // Switch to STEP
+    client.set_cycle_mode(CycleMode::Step).await.expect("Failed to set STEP mode");
+    wait_for_operation().await;
+    assert_eq!(server.get_cycle_mode().await, CycleMode::Step);
+    log::info!("✓ Switched to STEP mode");
+
+    // Switch to ONE CYCLE
+    client.set_cycle_mode(CycleMode::OneCycle).await.expect("Failed to set ONE CYCLE mode");
+    wait_for_operation().await;
+    assert_eq!(server.get_cycle_mode().await, CycleMode::OneCycle);
+    log::info!("✓ Switched to ONE CYCLE mode");
+
+    // Back to CONTINUOUS
+    client.set_cycle_mode(CycleMode::Continuous).await.expect("Failed to set CONTINUOUS mode");
+    wait_for_operation().await;
+    assert_eq!(server.get_cycle_mode().await, CycleMode::Continuous);
+    log::info!("✓ Switched back to CONTINUOUS mode");
+
+    log::info!("✓ Cycle mode sequence completed successfully");
+
+    // Clean up
+    server_handle.abort();
+});
+
+test_with_logging!(test_cycle_mode_error_handling, {
+    // Create mock server with initial cycle mode
+    let server = Arc::new(
+        MockServerBuilder::new()
+            .host("127.0.0.1")
+            .robot_port(ROBOT_CONTROL_PORT)
+            .file_port(FILE_CONTROL_PORT)
+            .with_cycle_mode(CycleMode::Continuous)
+            .build()
+            .await
+            .expect("Failed to build mock server"),
+    );
+
+    // Start server in background
+    let server_clone = Arc::clone(&server);
+    let server_handle = tokio::spawn(async move {
+        server_clone.run().await.expect("Failed to run mock server");
+    });
+
+    // Wait for server to be ready
+    wait_for_operation().await;
+
+    let client = create_test_client().await.expect("Failed to create client");
+
+    // Test normal operation should succeed
+    log::info!("Testing error handling...");
+    client.set_cycle_mode(CycleMode::Step).await.expect("Failed to set STEP mode");
+    wait_for_operation().await;
+    assert_eq!(server.get_cycle_mode().await, CycleMode::Step);
+    log::info!("✓ Normal operation succeeded");
+
+    // Test rapid mode changes
+    log::info!("Testing rapid mode changes...");
+    for i in 0..5 {
+        client.set_cycle_mode(CycleMode::Step).await.expect("Failed to set STEP mode");
+        wait_for_operation().await;
+        assert_eq!(server.get_cycle_mode().await, CycleMode::Step);
+
+        client.set_cycle_mode(CycleMode::OneCycle).await.expect("Failed to set ONE CYCLE mode");
+        wait_for_operation().await;
+        assert_eq!(server.get_cycle_mode().await, CycleMode::OneCycle);
+
+        client.set_cycle_mode(CycleMode::Continuous).await.expect("Failed to set CONTINUOUS mode");
+        wait_for_operation().await;
+        assert_eq!(server.get_cycle_mode().await, CycleMode::Continuous);
+
+        log::info!("✓ Rapid change iteration {} completed", i + 1);
+    }
+    log::info!("✓ Rapid mode changes completed");
+
+    log::info!("✓ Error handling test completed");
+
+    // Clean up
+    server_handle.abort();
+});

--- a/moto-hses-client/tests/integration/mod.rs
+++ b/moto-hses-client/tests/integration/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod alarm_operations;
 pub mod connection_management;
+pub mod cycle_mode_control;
 pub mod file_operations;
 pub mod hold_servo_control;
 pub mod io_operations;

--- a/moto-hses-mock/src/handlers/cycle_mode_switching.rs
+++ b/moto-hses-mock/src/handlers/cycle_mode_switching.rs
@@ -1,0 +1,58 @@
+//! Cycle mode switching command handler (0x84)
+
+use super::CommandHandler;
+use crate::state::MockState;
+use moto_hses_proto as proto;
+
+/// Handler for cycle mode switching command (0x84)
+pub struct CycleModeSwitchingHandler;
+
+impl CommandHandler for CycleModeSwitchingHandler {
+    fn handle(
+        &self,
+        message: &proto::HsesRequestMessage,
+        state: &mut MockState,
+    ) -> Result<Vec<u8>, proto::ProtocolError> {
+        // Validate instance (must be 2)
+        if message.sub_header.instance != 2 {
+            return Err(proto::ProtocolError::InvalidCommand);
+        }
+
+        // Validate attribute (must be 1)
+        if message.sub_header.attribute != 1 {
+            return Err(proto::ProtocolError::InvalidAttribute);
+        }
+
+        // Validate service (must be 0x10)
+        if message.sub_header.service != 0x10 {
+            return Err(proto::ProtocolError::InvalidService);
+        }
+
+        // Parse cycle mode from payload
+        if message.payload.len() < 4 {
+            return Err(proto::ProtocolError::Deserialization(
+                "Insufficient payload length".to_string(),
+            ));
+        }
+
+        let mode_value = u32::from_le_bytes([
+            message.payload[0],
+            message.payload[1],
+            message.payload[2],
+            message.payload[3],
+        ]);
+
+        let mode = match mode_value {
+            1 => proto::CycleMode::Step,
+            2 => proto::CycleMode::OneCycle,
+            3 => proto::CycleMode::Continuous,
+            _ => return Err(proto::ProtocolError::InvalidAttribute),
+        };
+
+        // Update state
+        state.set_cycle_mode(mode);
+
+        // Return empty payload (success response)
+        Ok(vec![])
+    }
+}

--- a/moto-hses-mock/src/handlers/job.rs
+++ b/moto-hses-mock/src/handlers/job.rs
@@ -146,25 +146,3 @@ impl CommandHandler for PmovHandler {
         }
     }
 }
-
-/// Handler for `SelectCycle` command (0x84)
-pub struct SelectCycleHandler;
-
-impl CommandHandler for SelectCycleHandler {
-    fn handle(
-        &self,
-        message: &proto::HsesRequestMessage,
-        _state: &mut MockState,
-    ) -> Result<Vec<u8>, proto::ProtocolError> {
-        let service = message.sub_header.service;
-
-        match service {
-            0x10 => {
-                // Select cycle type
-                // For now, just acknowledge the cycle selection
-                Ok(vec![])
-            }
-            _ => Err(proto::ProtocolError::InvalidService),
-        }
-    }
-}

--- a/moto-hses-mock/src/handlers/mod.rs
+++ b/moto-hses-mock/src/handlers/mod.rs
@@ -21,6 +21,7 @@ pub trait CommandHandler {
 
 // Re-export all handler modules
 pub mod alarm;
+pub mod cycle_mode_switching;
 pub mod file;
 pub mod io;
 pub mod job;

--- a/moto-hses-mock/src/handlers/registry.rs
+++ b/moto-hses-mock/src/handlers/registry.rs
@@ -7,11 +7,11 @@ use std::sync::Arc;
 
 // Import all handlers
 use super::alarm::{AlarmDataHandler, AlarmInfoHandler, AlarmResetHandler};
+use super::cycle_mode_switching::CycleModeSwitchingHandler;
 use super::file::FileControlHandler;
 use super::io::{IoHandler, RegisterHandler};
 use super::job::{
     ExecutingJobInfoHandler, JobSelectHandler, JobStartHandler, MovHandler, PmovHandler,
-    SelectCycleHandler,
 };
 use super::position::{
     BasePositionVarHandler, ExternalAxisVarHandler, PositionErrorHandler, PositionHandler,
@@ -87,8 +87,10 @@ impl CommandHandlerRegistry {
 
         // Job and movement handlers
         handlers.insert(0x83, Arc::new(HoldServoHandler) as Arc<dyn CommandHandler + Send + Sync>);
-        handlers
-            .insert(0x84, Arc::new(SelectCycleHandler) as Arc<dyn CommandHandler + Send + Sync>);
+        handlers.insert(
+            0x84,
+            Arc::new(CycleModeSwitchingHandler) as Arc<dyn CommandHandler + Send + Sync>,
+        );
         handlers.insert(0x86, Arc::new(JobStartHandler) as Arc<dyn CommandHandler + Send + Sync>);
         handlers.insert(0x87, Arc::new(JobSelectHandler) as Arc<dyn CommandHandler + Send + Sync>);
         handlers.insert(0x8a, Arc::new(MovHandler) as Arc<dyn CommandHandler + Send + Sync>);

--- a/moto-hses-mock/src/lib.rs
+++ b/moto-hses-mock/src/lib.rs
@@ -30,6 +30,7 @@ pub struct MockConfig {
     pub alarms: Vec<proto::Alarm>,
     pub alarm_history: Vec<proto::Alarm>,
     pub executing_job: Option<proto::ExecutingJobInfo>,
+    pub cycle_mode: proto::CycleMode,
 }
 
 impl MockConfig {
@@ -86,6 +87,7 @@ impl MockConfig {
             alarms: Vec::new(),
             alarm_history: Vec::new(),
             executing_job: Some(proto::ExecutingJobInfo::new("TEST.JOB".to_string(), 2, 1, 100)),
+            cycle_mode: proto::CycleMode::Continuous,
         }
     }
 

--- a/moto-hses-mock/src/server.rs
+++ b/moto-hses-mock/src/server.rs
@@ -36,6 +36,7 @@ impl MockServer {
             position: config.default_position.clone(),
             registers: config.registers.clone(),
             variables: config.variables.clone(),
+            cycle_mode: config.cycle_mode,
             ..Default::default()
         };
 
@@ -353,6 +354,12 @@ impl MockServer {
         let mut state = self.state.write().await;
         state.update_position(position);
     }
+
+    /// Get the current cycle mode
+    pub async fn get_cycle_mode(&self) -> proto::CycleMode {
+        let state = self.state.read().await;
+        state.get_cycle_mode()
+    }
 }
 
 /// Server builder for easy configuration
@@ -435,6 +442,12 @@ impl MockServerBuilder {
     #[must_use]
     pub fn with_variables(mut self, variables: std::collections::HashMap<u8, Vec<u8>>) -> Self {
         self.config.variables = variables;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_cycle_mode(mut self, mode: proto::CycleMode) -> Self {
+        self.config.cycle_mode = mode;
         self
     }
 

--- a/moto-hses-mock/src/state.rs
+++ b/moto-hses-mock/src/state.rs
@@ -20,6 +20,7 @@ pub struct MockState {
     pub servo_on: bool,
     pub hold_state: bool,
     pub hlock_state: bool,
+    pub cycle_mode: proto::CycleMode,
     pub files: HashMap<String, Vec<u8>>,
 }
 
@@ -180,6 +181,7 @@ impl Default for MockState {
             servo_on: true,
             hold_state: false,
             hlock_state: false,
+            cycle_mode: proto::CycleMode::Continuous,
             files,
         }
     }
@@ -296,6 +298,17 @@ impl MockState {
     #[must_use]
     pub const fn is_hlock_enabled(&self) -> bool {
         self.hlock_state
+    }
+
+    /// Set cycle mode
+    pub const fn set_cycle_mode(&mut self, mode: proto::CycleMode) {
+        self.cycle_mode = mode;
+    }
+
+    /// Get cycle mode
+    #[must_use]
+    pub const fn get_cycle_mode(&self) -> proto::CycleMode {
+        self.cycle_mode
     }
 }
 

--- a/moto-hses-proto/src/cycle_mode.rs
+++ b/moto-hses-proto/src/cycle_mode.rs
@@ -1,0 +1,100 @@
+//! Cycle mode switching command (0x84)
+
+use crate::commands::Command;
+use crate::error::ProtocolError;
+
+/// Cycle mode switching command (0x84)
+#[derive(Debug, Clone)]
+pub struct CycleModeSwitchingCommand {
+    pub mode: CycleMode,
+}
+
+impl CycleModeSwitchingCommand {
+    #[must_use]
+    pub const fn new(mode: CycleMode) -> Self {
+        Self { mode }
+    }
+}
+
+/// Cycle mode enumeration
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CycleMode {
+    Step = 1,
+    OneCycle = 2,
+    Continuous = 3,
+}
+
+impl Command for CycleModeSwitchingCommand {
+    type Response = ();
+
+    fn command_id() -> u16 {
+        0x84
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
+        Ok(vec![self.mode as u8, 0, 0, 0])
+    }
+
+    fn instance(&self) -> u16 {
+        2 // Fixed according to specification
+    }
+
+    fn attribute(&self) -> u8 {
+        1 // Fixed according to specification
+    }
+
+    fn service(&self) -> u8 {
+        0x10 // Set_Attribute_Single
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cycle_mode_switching_command_new() {
+        let command = CycleModeSwitchingCommand::new(CycleMode::Step);
+        assert_eq!(command.mode, CycleMode::Step);
+    }
+
+    #[test]
+    fn test_cycle_mode_switching_command_trait() {
+        let command = CycleModeSwitchingCommand::new(CycleMode::OneCycle);
+
+        assert_eq!(CycleModeSwitchingCommand::command_id(), 0x84);
+        assert_eq!(command.instance(), 2);
+        assert_eq!(command.attribute(), 1);
+        assert_eq!(command.service(), 0x10);
+    }
+
+    #[test]
+    fn test_cycle_mode_switching_command_serialize() {
+        let command = CycleModeSwitchingCommand::new(CycleMode::Step);
+        let data = command.serialize().unwrap();
+        assert_eq!(data, vec![1, 0, 0, 0]);
+
+        let command = CycleModeSwitchingCommand::new(CycleMode::OneCycle);
+        let data = command.serialize().unwrap();
+        assert_eq!(data, vec![2, 0, 0, 0]);
+
+        let command = CycleModeSwitchingCommand::new(CycleMode::Continuous);
+        let data = command.serialize().unwrap();
+        assert_eq!(data, vec![3, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_cycle_mode_enum_values() {
+        assert_eq!(CycleMode::Step as u8, 1);
+        assert_eq!(CycleMode::OneCycle as u8, 2);
+        assert_eq!(CycleMode::Continuous as u8, 3);
+    }
+
+    #[test]
+    fn test_cycle_mode_equality() {
+        assert_eq!(CycleMode::Step, CycleMode::Step);
+        assert_ne!(CycleMode::Step, CycleMode::OneCycle);
+        assert_ne!(CycleMode::OneCycle, CycleMode::Continuous);
+    }
+}

--- a/moto-hses-proto/src/lib.rs
+++ b/moto-hses-proto/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod alarm;
 pub mod commands;
 pub mod constants;
+pub mod cycle_mode;
 pub mod encoding;
 pub mod encoding_utils;
 pub mod error;
@@ -21,6 +22,7 @@ pub use commands::{
     VariableType, WriteIo, WriteRegister, WriteVar,
 };
 pub use constants::{FILE_CONTROL_PORT, ROBOT_CONTROL_PORT};
+pub use cycle_mode::{CycleMode, CycleModeSwitchingCommand};
 pub use encoding::TextEncoding;
 pub use error::ProtocolError;
 pub use file::response::{parse_file_content, parse_file_list};


### PR DESCRIPTION
## Overview

This PR implements the 0x84 cycle mode switching command for the HSES protocol, enabling clients to control robot execution modes (Step, One Cycle, Continuous).

## Major Changes

✨ **Protocol Layer**
- Add `CycleModeSwitchingCommand` struct with proper serialization
- Add `CycleMode` enum with Step, OneCycle, and Continuous variants
- Implement `Command` trait with fixed instance/attribute/service values

🔧 **Client API**
- Add `set_cycle_mode()` method to `HsesClient`
- Support all three cycle modes with type-safe API
- Proper error handling and retry logic

🏗️ **Mock Server**
- Add `CycleModeSwitchingHandler` for 0x84 command processing
- Extend `MockState` with cycle mode tracking
- Add state verification methods for testing

🧪 **Testing & Examples**
- Comprehensive integration tests with MockServer state verification
- Example code demonstrating cycle mode control
- Unit tests for protocol layer components

📚 **Documentation**
- Update client README with new features and examples
- Add implementation plan with quality assurance guidelines
- Include testing patterns for future command implementations

## Technical Details

- **Command ID**: 0x84
- **Instance**: 2 (fixed)
- **Attribute**: 1 (fixed)  
- **Service**: 0x10 (Set_Attribute_Single)
- **Payload**: 4-byte 32-bit integer (1: Step, 2: OneCycle, 3: Continuous)
- **Response**: Status only (no payload)

## Breaking Changes

None - this is a new feature addition.

## Related Issues

Implements cycle mode control functionality for robot execution management.