### PR TITLE
fix: improve I/O category ranges and change processing unit from bool to byte

### DIFF
--- a/docs/specs/hses-protocol.md
+++ b/docs/specs/hses-protocol.md
@@ -721,27 +721,27 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
 
 - **Command**: 0x78
 - **Instance**: Logical number of the I/O data
-  - `1 to 128`: Robot user input
-  - `1001 to 1128`: Robot user output
-  - `2001 to 2127`: External input
-  - `2501 to 2628`: Network input
+  - `1 to 512`: Robot user input
+  - `1001 to 1512`: Robot user output
+  - `2001 to 2128`: External input
+  - `2701 to 2956`: Network input
   - `3001 to 3128`: External output
-  - `3501 to 3628`: Network output
-  - `4001 to 4160`: Robot system input
-  - `5001 to 5200`: Robot system output
+  - `3701 to 3956`: Network output
+  - `4001 to 4256`: Robot system input
+  - `5001 to 5512`: Robot system output
   - `6001 to 6064`: Interface panel input
   - `7001 to 7999`: Auxiliary relay
-  - `8001 to 8064`: Robot control status signal
-  - `8201 to 8220`: Pseudo input
+  - `8001 to 8512`: Robot control status signal
+  - `8701 to 8720`: Pseudo input
 - **Attribute**: Fixed to 1
 - **Service**:
   - `0x0E` (Get_Attribute_Single): Read out of all I/O data is enabled
   - `0x10` (Set_Attribute_Single): Only network input signal is writable
-- **Payload**: Data exists during writing operation only
-  - 32-bit integer (4 bytes): I/O data
-    - Byte 0 : IO Data
-    - Byte 1-3: Reserved
-  - Data exists during the writing operation only
+- **Payload**: Data exists during reading operation only
+  - 1 byte: I/O data (8 bits representing 8 I/O states)
+    - Bit 0-7: I/O states (0 = OFF, 1 = ON)
+    - Each bit represents one I/O state
+  - I/O data exists only when requested by the client
 
 **Response Structure:**
 
@@ -754,9 +754,9 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
   - `2`: 2 WORD of added status data
 - **Added status**: Error code specified by the added status size
 - **Payload**: Data exists during reading operation only
-  - 32-bit integer (4 bytes): I/O data
-    - Byte 0 : IO Data
-    - Byte 1-3: Reserved
+  - 1 byte: I/O data (8 bits representing 8 I/O states)
+    - Bit 0-7: I/O states (0 = OFF, 1 = ON)
+    - Each bit represents one I/O state
   - I/O data exists only when requested by the client
 
 **Note**: For detailed specifications of all commands, refer to the official HSES manual. The above examples show the basic structure and common patterns used in robot control commands.

--- a/moto-hses-client/examples/io_operations.rs
+++ b/moto-hses-client/examples/io_operations.rs
@@ -5,92 +5,95 @@
 use log::info;
 
 use moto_hses_client::{ClientConfig, HsesClient};
+use moto_hses_proto::{ROBOT_CONTROL_PORT, TextEncoding};
 use std::time::Duration;
 use tokio::time::sleep;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
-    // Create client configuration
-    let config = ClientConfig {
-        host: "127.0.0.1".to_string(),
-        port: moto_hses_proto::ROBOT_CONTROL_PORT,
-        timeout: Duration::from_secs(5),
-        retry_count: 3,
-        retry_delay: Duration::from_millis(100),
-        buffer_size: 8192,
-        text_encoding: moto_hses_proto::TextEncoding::ShiftJis,
+    let args: Vec<String> = std::env::args().collect();
+
+    let (host, robot_port) = match args.as_slice() {
+        [_, host, robot_port] => {
+            // Format: [host] [robot_port]
+            let robot_port: u16 =
+                robot_port.parse().map_err(|_| format!("Invalid robot port: {robot_port}"))?;
+
+            (host.to_string(), robot_port)
+        }
+        _ => {
+            // Default: 127.0.0.1:DEFAULT_PORT
+            ("127.0.0.1".to_string(), ROBOT_CONTROL_PORT)
+        }
     };
 
-    // Create client
-    let client = HsesClient::new_with_config(config).await?;
-    info!("Connected successfully!");
+    // Create custom configuration
+    let config = ClientConfig {
+        host: host.to_string(),
+        port: robot_port,
+        timeout: Duration::from_millis(500),
+        retry_count: 5,
+        retry_delay: Duration::from_millis(200),
+        buffer_size: 8192,
+        text_encoding: TextEncoding::ShiftJis,
+    };
 
-    // Example I/O operations
-    info!("\n=== I/O Operations Example ===");
+    // Connect to the controller
+    let client = match HsesClient::new_with_config(config).await {
+        Ok(client) => {
+            info!("✓ Successfully connected to controller");
+            client
+        }
+        Err(e) => {
+            info!("✗ Failed to connect: {e}");
+            return Ok(());
+        }
+    };
 
-    // Read robot user input (I/O number 1-128)
-    info!("Reading robot user input I/O #1...");
-    match client.read_io(1).await {
-        Ok(value) => info!("I/O #1 state: {}", if value { "ON" } else { "OFF" }),
-        Err(e) => info!("Failed to read I/O #1: {e}"),
+    info!("=== 0x78 Command (I/O Operations) ===\n");
+
+    // Read robot system input (I/O number 4001-4256)
+    info!("Reading robot system input I/O #4004...");
+    match client.read_io(4004).await {
+        Ok(value) => info!("I/O #4004: 0b{value:08b}"),
+        Err(e) => info!("Failed to read I/O #4004: {e}"),
     }
 
-    // Read robot user output (I/O number 1001-1128)
-    info!("Reading robot user output I/O #1001...");
-    match client.read_io(1001).await {
-        Ok(value) => info!("I/O #1001 state: {}", if value { "ON" } else { "OFF" }),
-        Err(e) => info!("Failed to read I/O #1001: {e}"),
+    // Read robot user output (I/O number 5001-5512)
+    info!("Reading robot user output I/O #5032...");
+    match client.read_io(5032).await {
+        Ok(value) => info!("I/O #5032: 0b{value:08b}"),
+        Err(e) => info!("Failed to read I/O #5032: {e}"),
     }
 
-    // Write to robot user output (only network input signals are writable)
-    info!("Writing to robot user output I/O #1001...");
-    match client.write_io(1001, true).await {
-        Ok(()) => info!("Successfully set I/O #1001 to ON"),
-        Err(e) => info!("Failed to write I/O #1001: {e}"),
+    // Read robot control status signal (I/O number 8001-8512)
+    info!("Reading robot control status signal I/O #8002...");
+    match client.read_io(8002).await {
+        Ok(value) => info!("I/O #8002: 0b{value:08b}"),
+        Err(e) => info!("Failed to read I/O #8002: {e}"),
+    }
+
+    // Read pseudo input (I/O number 8701-8720)
+    info!("Reading pseudo input I/O #8701...");
+    match client.read_io(8701).await {
+        Ok(value) => info!("I/O #8701: 0b{value:08b}"),
+        Err(e) => info!("Failed to read I/O #8701: {e}"),
+    }
+
+    // Write to network input (I/O number 2701-2956 only network input signals are writable)
+    info!("Writing to network input I/O #2701...");
+    match client.write_io(2701, 0b0100_0001).await {
+        Ok(()) => info!("Successfully set I/O #2701 to 0b01000001"),
+        Err(e) => info!("Failed to write I/O #2701: {e}"),
     }
 
     // Verify the write operation
     sleep(Duration::from_millis(100)).await;
-    info!("Verifying I/O #1001 state...");
-    match client.read_io(1001).await {
-        Ok(value) => info!("I/O #1001 state after write: {}", if value { "ON" } else { "OFF" }),
-        Err(e) => info!("Failed to read I/O #1001: {e}"),
-    }
-
-    // Additional I/O operations
-    info!("\n=== Additional I/O Operations ===");
-    match client.read_io(2).await {
-        Ok(value) => info!("I/O #2 state: {}", if value { "ON" } else { "OFF" }),
-        Err(e) => info!("Failed to read I/O #2: {e}"),
-    }
-
-    match client.write_io(1002, false).await {
-        Ok(()) => info!("Successfully set I/O #1002 to OFF"),
-        Err(e) => info!("Failed to write I/O #1002: {e}"),
-    }
-
-    // Test error handling
-    info!("\n--- Error Handling Tests ---");
-
-    // Test invalid I/O number
-    match client.read_io(65535).await {
-        Ok(value) => {
-            info!("✗ Invalid I/O number succeeded unexpectedly: {value}");
-        }
-        Err(e) => {
-            info!("✓ Invalid I/O number correctly failed: {e}");
-        }
-    }
-
-    // Test invalid I/O number for write
-    match client.write_io(65535, true).await {
-        Ok(()) => {
-            info!("✗ Invalid I/O number write succeeded unexpectedly");
-        }
-        Err(e) => {
-            info!("✓ Invalid I/O number write correctly failed: {e}");
-        }
+    info!("Verifying I/O #2701 state...");
+    match client.read_io(2701).await {
+        Ok(value) => info!("I/O #2701 after write: 0b{value:08b}"),
+        Err(e) => info!("Failed to read I/O #2701: {e}"),
     }
 
     info!("\nI/O operations completed.");

--- a/moto-hses-client/tests/integration/io_operations.rs
+++ b/moto-hses-client/tests/integration/io_operations.rs
@@ -19,20 +19,20 @@ test_with_logging!(test_read_io, {
     // Test reading robot user input I/O
     log::info!("Reading robot user input I/O #1...");
     let io1_state = client.read_io(1).await.expect("Failed to read I/O #1");
-    log::info!("I/O #1 state: {io1_state}");
-    assert!(io1_state, "I/O #1 should be ON (initial state)");
+    log::info!("I/O #1 state: 0b{io1_state:08b}");
+    assert_eq!(io1_state, 0b0000_0001, "I/O #1 should be ON (initial state)");
 
     // Test reading robot user output I/O
     log::info!("Reading robot user output I/O #1001...");
     let io1001_state = client.read_io(1001).await.expect("Failed to read I/O #1001");
-    log::info!("I/O #1001 state: {io1001_state}");
-    assert!(!io1001_state, "I/O #1001 should be OFF (initial state)");
+    log::info!("I/O #1001 state: 0b{io1001_state:08b}");
+    assert_eq!(io1001_state, 0b0000_0000, "I/O #1001 should be OFF (initial state)");
 
     // Test reading additional I/O as per legacy example
     log::info!("Reading robot user input I/O #2...");
     let io2_state = client.read_io(2).await.expect("Failed to read I/O #2");
-    log::info!("I/O #2 state: {io2_state}");
-    assert!(!io2_state, "I/O #2 should be OFF (initial state)");
+    log::info!("I/O #2 state: 0b{io2_state:08b}");
+    assert_eq!(io2_state, 0b0000_0000, "I/O #2 should be OFF (initial state)");
 
     log::info!("I/O state verification passed");
 });
@@ -44,7 +44,7 @@ test_with_logging!(test_write_io, {
 
     // Test writing to robot user output I/O (as per legacy example)
     log::info!("Writing to robot user output I/O #1001...");
-    client.write_io(1001, true).await.expect("Failed to write to I/O #1001");
+    client.write_io(1001, 0b0000_0001).await.expect("Failed to write to I/O #1001");
     log::info!("Successfully set I/O #1001 to ON");
 
     // Wait a moment and verify the change (as per legacy example)
@@ -53,12 +53,12 @@ test_with_logging!(test_write_io, {
     let io_state_after_write =
         client.read_io(1001).await.expect("Failed to read I/O #1001 after write");
 
-    log::info!("I/O #1001 state after write: {io_state_after_write}");
-    assert!(io_state_after_write, "I/O #1001 should be ON after write");
+    log::info!("I/O #1001 state after write: 0b{io_state_after_write:08b}");
+    assert_eq!(io_state_after_write, 0b0000_0001, "I/O #1001 should be ON after write");
 
     // Additional I/O operations (as per legacy example)
     log::info!("Writing to robot user output I/O #1002...");
-    client.write_io(1002, false).await.expect("Failed to write OFF to I/O #1002");
+    client.write_io(1002, 0b0000_0000).await.expect("Failed to write OFF to I/O #1002");
     log::info!("Successfully set I/O #1002 to OFF");
 
     // Wait a moment and verify the change
@@ -67,8 +67,8 @@ test_with_logging!(test_write_io, {
     let io1002_state_after_write =
         client.read_io(1002).await.expect("Failed to read I/O #1002 after write");
 
-    log::info!("I/O #1002 state after write: {io1002_state_after_write}");
-    assert!(!io1002_state_after_write, "I/O #1002 should be OFF after write");
+    log::info!("I/O #1002 state after write: 0b{io1002_state_after_write:08b}");
+    assert_eq!(io1002_state_after_write, 0b0000_0000, "I/O #1002 should be OFF after write");
 });
 
 test_with_logging!(test_read_and_write_io_with_invalid_number, {
@@ -91,7 +91,7 @@ test_with_logging!(test_read_and_write_io_with_invalid_number, {
 
     // Test invalid I/O number for write
     log::info!("Testing invalid I/O number write...");
-    match client.write_io(65535, true).await {
+    match client.write_io(65535, 0b0000_0001).await {
         Ok(()) => {
             log::error!("✗ Invalid I/O number write succeeded unexpectedly");
             unreachable!("Writing to invalid I/O number should return error");

--- a/moto-hses-mock/tests/protocol_communication_tests.rs
+++ b/moto-hses-mock/tests/protocol_communication_tests.rs
@@ -139,7 +139,7 @@ async fn test_io_read_command() {
             proto::HsesResponseMessage::decode(&buf[..n]).expect("Failed to decode response");
         assert_eq!(response.header.ack, 1); // Should be ACK
         assert_eq!(response.sub_header.service, 0x8e); // 0x0e + 0x80
-        assert_eq!(response.payload.len(), 4); // I/O value should be 4 bytes
+        assert_eq!(response.payload.len(), 1); // I/O value should be 1 byte
     } else {
         // Socket might not have data yet
         // This is acceptable for this test
@@ -356,7 +356,7 @@ async fn test_io_read_command_0x78() {
         assert_eq!(response.header.ack, 1); // Should be ACK
         assert_eq!(response.sub_header.service, 0x8e); // Response service
         assert_eq!(response.sub_header.status, 0x00); // Normal status
-        assert_eq!(response.payload.len(), 4); // I/O data is 4 bytes
+        assert_eq!(response.payload.len(), 1); // I/O data is 1 byte
     } else {
         // Socket might not have data yet
         // This is acceptable for this test

--- a/moto-hses-proto/src/commands/io.rs
+++ b/moto-hses-proto/src/commands/io.rs
@@ -3,6 +3,82 @@
 use super::command_trait::Command;
 use crate::error::ProtocolError;
 
+/// I/O categories according to HSES protocol specification
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IoCategory {
+    /// Robot user input (1-512)
+    RobotUserInput,
+    /// Robot user output (1001-1512)
+    RobotUserOutput,
+    /// External input (2001-2128)
+    ExternalInput,
+    /// Network input (2701-2956)
+    NetworkInput,
+    /// External output (3001-3128)
+    ExternalOutput,
+    /// Network output (3701-3956)
+    NetworkOutput,
+    /// Robot system input (4001-4256)
+    RobotSystemInput,
+    /// Robot system output (5001-5512)
+    RobotSystemOutput,
+    /// Interface panel input (6001-6064)
+    InterfacePanelInput,
+    /// Auxiliary relay (7001-7999)
+    AuxiliaryRelay,
+    /// Robot control status signal (8001-8512)
+    RobotControlStatusSignal,
+    /// Pseudo input (8701-8720)
+    PseudoInput,
+}
+
+impl IoCategory {
+    /// Get the I/O category for a given I/O number
+    #[must_use]
+    pub const fn from_io_number(io_number: u16) -> Option<Self> {
+        match io_number {
+            1..=512 => Some(Self::RobotUserInput),
+            1001..=1512 => Some(Self::RobotUserOutput),
+            2001..=2128 => Some(Self::ExternalInput),
+            2701..=2956 => Some(Self::NetworkInput),
+            3001..=3128 => Some(Self::ExternalOutput),
+            3701..=3956 => Some(Self::NetworkOutput),
+            4001..=4256 => Some(Self::RobotSystemInput),
+            5001..=5512 => Some(Self::RobotSystemOutput),
+            6001..=6064 => Some(Self::InterfacePanelInput),
+            7001..=7999 => Some(Self::AuxiliaryRelay),
+            8001..=8512 => Some(Self::RobotControlStatusSignal),
+            8701..=8720 => Some(Self::PseudoInput),
+            _ => None,
+        }
+    }
+
+    /// Check if an I/O number is valid
+    #[must_use]
+    pub const fn is_valid_io_number(io_number: u16) -> bool {
+        Self::from_io_number(io_number).is_some()
+    }
+
+    /// Get the range of I/O numbers for this category
+    #[must_use]
+    pub const fn range(&self) -> (u16, u16) {
+        match self {
+            Self::RobotUserInput => (1, 512),
+            Self::RobotUserOutput => (1001, 1512),
+            Self::ExternalInput => (2001, 2128),
+            Self::NetworkInput => (2701, 2956),
+            Self::ExternalOutput => (3001, 3128),
+            Self::NetworkOutput => (3701, 3956),
+            Self::RobotSystemInput => (4001, 4256),
+            Self::RobotSystemOutput => (5001, 5512),
+            Self::InterfacePanelInput => (6001, 6064),
+            Self::AuxiliaryRelay => (7001, 7999),
+            Self::RobotControlStatusSignal => (8001, 8512),
+            Self::PseudoInput => (8701, 8720),
+        }
+    }
+}
+
 /// Read I/O command (0x78)
 #[derive(Debug, Clone)]
 pub struct ReadIo {
@@ -17,7 +93,7 @@ impl ReadIo {
 }
 
 impl Command for ReadIo {
-    type Response = bool;
+    type Response = u8;
 
     fn command_id() -> u16 {
         0x78
@@ -44,12 +120,12 @@ impl Command for ReadIo {
 #[derive(Debug, Clone)]
 pub struct WriteIo {
     pub io_number: u16,
-    pub value: bool,
+    pub value: u8,
 }
 
 impl WriteIo {
     #[must_use]
-    pub const fn new(io_number: u16, value: bool) -> Self {
+    pub const fn new(io_number: u16, value: u8) -> Self {
         Self { io_number, value }
     }
 }
@@ -62,8 +138,7 @@ impl Command for WriteIo {
     }
 
     fn serialize(&self) -> Result<Vec<u8>, ProtocolError> {
-        let value = u8::from(self.value);
-        Ok(vec![value, 0, 0, 0])
+        Ok(vec![self.value, 0, 0, 0])
     }
 
     fn instance(&self) -> u16 {
@@ -76,5 +151,69 @@ impl Command for WriteIo {
 
     fn service(&self) -> u8 {
         0x10 // Set_Attribute_Single
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_io_category_from_io_number() {
+        assert_eq!(IoCategory::from_io_number(1), Some(IoCategory::RobotUserInput));
+        assert_eq!(IoCategory::from_io_number(512), Some(IoCategory::RobotUserInput));
+        assert_eq!(IoCategory::from_io_number(1001), Some(IoCategory::RobotUserOutput));
+        assert_eq!(IoCategory::from_io_number(1512), Some(IoCategory::RobotUserOutput));
+        assert_eq!(IoCategory::from_io_number(2701), Some(IoCategory::NetworkInput));
+        assert_eq!(IoCategory::from_io_number(2956), Some(IoCategory::NetworkInput));
+        assert_eq!(IoCategory::from_io_number(0), None);
+        assert_eq!(IoCategory::from_io_number(513), None);
+        assert_eq!(IoCategory::from_io_number(1000), None);
+        assert_eq!(IoCategory::from_io_number(1513), None);
+    }
+
+    #[test]
+    fn test_io_category_is_valid_io_number() {
+        assert!(IoCategory::is_valid_io_number(1));
+        assert!(IoCategory::is_valid_io_number(512));
+        assert!(IoCategory::is_valid_io_number(1001));
+        assert!(IoCategory::is_valid_io_number(1512));
+        assert!(IoCategory::is_valid_io_number(2701));
+        assert!(IoCategory::is_valid_io_number(2956));
+        assert!(!IoCategory::is_valid_io_number(0));
+        assert!(!IoCategory::is_valid_io_number(513));
+        assert!(!IoCategory::is_valid_io_number(1000));
+        assert!(!IoCategory::is_valid_io_number(1513));
+    }
+
+    #[test]
+    fn test_io_category_range() {
+        assert_eq!(IoCategory::RobotUserInput.range(), (1, 512));
+        assert_eq!(IoCategory::RobotUserOutput.range(), (1001, 1512));
+        assert_eq!(IoCategory::NetworkInput.range(), (2701, 2956));
+        assert_eq!(IoCategory::PseudoInput.range(), (8701, 8720));
+    }
+
+    #[test]
+    fn test_io_ranges_consistency() {
+        // Test that all ranges are properly defined
+        for category in [
+            IoCategory::RobotUserInput,
+            IoCategory::RobotUserOutput,
+            IoCategory::ExternalInput,
+            IoCategory::NetworkInput,
+            IoCategory::ExternalOutput,
+            IoCategory::NetworkOutput,
+            IoCategory::RobotSystemInput,
+            IoCategory::RobotSystemOutput,
+            IoCategory::InterfacePanelInput,
+            IoCategory::AuxiliaryRelay,
+            IoCategory::RobotControlStatusSignal,
+            IoCategory::PseudoInput,
+        ] {
+            let (start, end) = category.range();
+            assert!(start <= end, "Range {category:?}: start ({start}) should be <= end ({end})");
+            assert!(start > 0, "Range {category:?}: start ({start}) should be > 0");
+        }
     }
 }


### PR DESCRIPTION
## Overview
This PR addresses critical issues with I/O operations in the HSES protocol implementation, specifically improving I/O category range validation and changing the processing unit from boolean to byte-level operations.

## Major Changes
✨ **Protocol Layer Improvements**
- Add comprehensive IoCategory enum with proper value ranges
- Implement DRY principle with enum-based range management
- Add const fn methods for compile-time optimization

🔧 **I/O Processing Unit Change**
- Change I/O command processing from bool to u8 (1 byte = 8 I/O states)
- Update Mock server to handle 1-byte I/O responses
- Fix I/O number range validation to match HSES specification

🏗️ **Architecture Improvements**
- Move I/O category validation to protocol layer
- Eliminate hardcoded ranges in Mock server
- Improve code maintainability with single source of truth

## Technical Details
- **I/O Categories**: 12 categories with proper value ranges (1-512, 1001-1512, etc.)
- **Processing Unit**: 1 byte represents 8 I/O states (bit 0-7)
- **Validation**: Compile-time constant functions for performance
- **Testing**: Comprehensive test coverage for all I/O categories

## Breaking Changes
- I/O read/write operations now return/accept u8 instead of bool
- Mock server I/O responses changed from 4 bytes to 1 byte
- I/O number range validation updated to match specification

## Related Issues
- Resolves I/O payload size mismatch between client and robot
- Fixes 'Invalid response length for I/O read' errors
- Improves protocol compliance with HSES specification