### PR TITLE
refactor: rename form variables to configuration

### DIFF
--- a/docs/specs/hses-protocol.md
+++ b/docs/specs/hses-protocol.md
@@ -529,10 +529,10 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
   - _Note: Cartesian value can select the base coordinate only. (It cannot select the robot, user and tool coordinates.)_
 - **Attribute**: Specifies the position information data number
   - `1`: Data type (0: pulse value / 16: base coordinate value)
-  - `2`: Form (refer to "Details of data")
+  - `2`: Configuration (refer to "Details of data")
   - `3`: Tool number
   - `4`: User coordinate number
-  - `5`: Extended form (refer to "Details of data")
+  - `5`: Extended configuration (refer to "Details of data")
   - `6`: First axis data
   - `7`: Second axis data
   - `8`: Third axis data
@@ -566,7 +566,7 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
 - `0`: Pulse value
 - `16`: Base coordinate value
 
-**Form (32-bit integer 2):**
+**Configuration (32-bit integer 2):**
 
 - 8 bits (bit0 to bit7):
   - `bit0`: 0: Front, 1: Back
@@ -576,7 +576,7 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
   - `bit4`: 0: θT < 180, 1: θT ≥ 180
   - `bit5`: 0: θS < 180, 1: θS ≥ 180
   - `bit6`: 0: Redundant front, 1: Redundant back
-  - `bit7`: 0: Previous step regarded reverse conversion specified, 1: Form regarded reverse conversion specified
+  - `bit7`: 0: Previous step regarded inverse kinematics specified, 1: Configuration regarded inverse kinematics specified
 
 **Tool Number (32-bit integer 3):**
 
@@ -586,7 +586,7 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
 
 - User coordinate number
 
-**Extended Form (32-bit integer 5):**
+**Extended Configuration (32-bit integer 5):**
 
 - 8 bits (bit0 to bit7):
   - `bit0`: 0: θL < 180, 1: θL ≥ 180
@@ -972,10 +972,10 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
   - Note: Since the extended variable is an optional function, follow the numbers of the variables specified by the parameter when specifying the number
 - **Attribute**: Axis information data number
   - `1`: Data type
-  - `2`: Form
+  - `2`: Configuration
   - `3`: Tool number
   - `4`: User coordinate number
-  - `5`: Extended form
+  - `5`: Extended configuration
   - `6`: Coordinated data of the first axis
   - `7`: Coordinated data of the second axis
   - `8`: Coordinated data of the third axis
@@ -995,10 +995,10 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
       - `17`: Robot coordinated value
       - `18`: Tool coordinated value
       - `19`: User coordinated value
-    - Integer 2: Form (see Details of data)
+    - Integer 2: Configuration (see Details of data)
     - Integer 3: Tool number
     - Integer 4: User coordinate number
-    - Integer 5: Extended form (see Details of data)
+    - Integer 5: Extended configuration (see Details of data)
     - Integers 6-13: Coordinate data (1st to 8th axis)
 
 **Response Structure:**
@@ -1018,7 +1018,7 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
 
 **Details of Data:**
 
-**Form (8 bits):**
+**Configuration (8 bits):**
 
 - `bit0`: 0: Front, 1: Back
 - `bit1`: 0: Upper arm, 1: Lower arm
@@ -1027,9 +1027,9 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
 - `bit4`: 0: θT < 180, 1: θT ≥ 180
 - `bit5`: 0: θS < 180, 1: θS ≥ 180
 - `bit6`: 0: Redundant front, 1: Redundant back
-- `bit7`: 0: Previous step regarded reverse conversion specified, 1: Form regarded reverse conversion specified
+- `bit7`: 0: Previous step regarded inverse kinematics specified, 1: Configuration regarded inverse kinematics specified
 
-**Extended form (8 bits):**
+**Extended configuration (8 bits):**
 
 - `bit0`: 0: θL < 180, 1: θL ≥ 180
 - `bit1`: 0: θU < 180, 1: θU ≥ 180
@@ -1038,7 +1038,7 @@ HSES (High Speed Ethernet Server) is a UDP-based communication protocol for Yask
 - `bit4`: 0: θW < 180, 1: θW ≥ 180
 - `bit5-7`: Reserve
 
-**Note**: For detailed form specifications, refer to "3.9.4 Flip/ No flip" in "FS100 OPERATOR'S MANUAL" prepared for each application.
+**Note**: For detailed configuration specifications, refer to "3.9.4 Flip/ No flip" in "FS100 OPERATOR'S MANUAL" prepared for each application.
 
 #### Base Position Type Variable (Bp) Reading / Writing Command (Command 0x80)
 
@@ -1667,7 +1667,7 @@ This data interlocks the P.P (Programming Pendant) and I/O operation system sign
     - Integer 1: Number (Maximum: 9)
     - Integers 2-118: P variable data
       - Data type: 0 (Pulse value), 16 (Base coordinated value), 17 (Robot coordinated value), 18 (Tool coordinated value), 19 (User coordinated value)
-      - Form, Tool number, User coordinate number, Extended form
+      - Configuration, Tool number, User coordinate number, Extended configuration
       - First to Eighth coordinate data
       - Variable data part is valid only when writing
       - When reading, only the number of data is valid

--- a/moto-hses-proto/src/payload/position.rs
+++ b/moto-hses-proto/src/payload/position.rs
@@ -5,44 +5,57 @@ use crate::payload::HsesPayload;
 use bytes::Buf;
 
 // Configuration bit field definitions
+// S(Swing,J1) Axis Placement
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum J1Placement {
+pub enum SAxisPlacement {
     Front,
     Back,
 }
 
+// U(Upper arm,J3) Axis Placement
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum J3Placement {
+pub enum UAxisPlacement {
     Up,
     Down,
 }
 
+// B(Bend,J5) Axis Placement
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum J5Placement {
+pub enum BAxisPlacement {
     Flip,
     NoFlip,
 }
 
+// R(Rotate,J4) Axis Turn Number
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum J4TurnNum {
+pub enum RAxisTurnNum {
+    // R < 180
     Single,
+    // R ≥ 180
     Double,
 }
 
+// T(Twist,J6) Axis Turn Number
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum J6TurnNum {
+pub enum TAxisTurnNum {
+    // T < 180
     Single,
+    // T ≥ 180
     Double,
 }
 
+// S(Swing,J1) Axis Turn Number
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum J1TurnNum {
+pub enum SAxisTurnNum {
+    // S < 180
     Single,
+    // S ≥ 180
     Double,
 }
 
+// Redundant S Axis Placement
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RedundantJ1Placement {
+pub enum RedundantSAxisPlacement {
     Front,
     Back,
 }
@@ -56,53 +69,68 @@ pub enum IkSolutionBasis {
 }
 
 // Extended configuration bit field definitions
+// L(Lower arm,J2) Axis Turn Number
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum J2TurnNum {
+pub enum LAxisTurnNum {
+    // L < 180
     Single,
+    // L ≥ 180
     Double,
 }
 
+// U(Upper arm,J3) Axis Turn Number
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum J3TurnNum {
+pub enum UAxisTurnNum {
+    // U < 180
     Single,
+    // U ≥ 180
     Double,
 }
 
+// B(Bend,J5) Axis Turn Number
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum J5TurnNum {
+pub enum BAxisTurnNum {
+    // B < 180
     Single,
+    // B ≥ 180
     Double,
 }
 
+// E(External axis) Axis Turn Number
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EAxisTurnNum {
+    // E < 180
     Single,
+    // E ≥ 180
     Double,
 }
 
+// W(Wrist-extension axis) Axis Turn Number
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WAxisTurnNum {
+    // W < 180
     Single,
+    // W ≥ 180
     Double,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Configuration {
-    pub j1_placement: J1Placement,
-    pub j3_placement: J3Placement,
-    pub j5_placement: J5Placement,
-    pub j4_turn_num: J4TurnNum,
-    pub j6_turn_num: J6TurnNum,
-    pub j1_turn_num: J1TurnNum,
-    pub redundant_j1_placement: RedundantJ1Placement,
+    pub s_placement: SAxisPlacement,
+    pub u_placement: UAxisPlacement,
+    pub b_placement: BAxisPlacement,
+    pub r_turn_num: RAxisTurnNum,
+    pub t_turn_num: TAxisTurnNum,
+    pub s_turn_num: SAxisTurnNum,
+    pub redundant_s_placement: RedundantSAxisPlacement,
     pub ik_solution_basis: IkSolutionBasis,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExtendedConfiguration {
-    pub bit0: J2TurnNum,
-    pub bit1: J3TurnNum,
-    pub bit2: J5TurnNum,
+    pub bit0: LAxisTurnNum,
+    pub bit1: UAxisTurnNum,
+    pub bit2: BAxisTurnNum,
     pub bit3: EAxisTurnNum,
     pub bit4: WAxisTurnNum,
     pub bit5: bool, // Reserve
@@ -115,16 +143,24 @@ impl Configuration {
     #[must_use]
     pub const fn from_raw(value: u8) -> Self {
         Self {
-            j1_placement: if value & 0x01 == 0 { J1Placement::Front } else { J1Placement::Back },
-            j3_placement: if value & 0x02 == 0 { J3Placement::Up } else { J3Placement::Down },
-            j5_placement: if value & 0x04 == 0 { J5Placement::Flip } else { J5Placement::NoFlip },
-            j4_turn_num: if value & 0x08 == 0 { J4TurnNum::Single } else { J4TurnNum::Double },
-            j6_turn_num: if value & 0x10 == 0 { J6TurnNum::Single } else { J6TurnNum::Double },
-            j1_turn_num: if value & 0x20 == 0 { J1TurnNum::Single } else { J1TurnNum::Double },
-            redundant_j1_placement: if value & 0x40 == 0 {
-                RedundantJ1Placement::Front
+            s_placement: if value & 0x01 == 0 {
+                SAxisPlacement::Front
             } else {
-                RedundantJ1Placement::Back
+                SAxisPlacement::Back
+            },
+            u_placement: if value & 0x02 == 0 { UAxisPlacement::Up } else { UAxisPlacement::Down },
+            b_placement: if value & 0x04 == 0 {
+                BAxisPlacement::Flip
+            } else {
+                BAxisPlacement::NoFlip
+            },
+            r_turn_num: if value & 0x08 == 0 { RAxisTurnNum::Single } else { RAxisTurnNum::Double },
+            t_turn_num: if value & 0x10 == 0 { TAxisTurnNum::Single } else { TAxisTurnNum::Double },
+            s_turn_num: if value & 0x20 == 0 { SAxisTurnNum::Single } else { SAxisTurnNum::Double },
+            redundant_s_placement: if value & 0x40 == 0 {
+                RedundantSAxisPlacement::Front
+            } else {
+                RedundantSAxisPlacement::Back
             },
             ik_solution_basis: if value & 0x80 == 0 {
                 IkSolutionBasis::PreviousStep
@@ -138,25 +174,25 @@ impl Configuration {
     #[must_use]
     pub const fn to_raw(self) -> u8 {
         let mut value = 0u8;
-        if matches!(self.j1_placement, J1Placement::Back) {
+        if matches!(self.s_placement, SAxisPlacement::Back) {
             value |= 0x01;
         }
-        if matches!(self.j3_placement, J3Placement::Down) {
+        if matches!(self.u_placement, UAxisPlacement::Down) {
             value |= 0x02;
         }
-        if matches!(self.j5_placement, J5Placement::NoFlip) {
+        if matches!(self.b_placement, BAxisPlacement::NoFlip) {
             value |= 0x04;
         }
-        if matches!(self.j4_turn_num, J4TurnNum::Double) {
+        if matches!(self.r_turn_num, RAxisTurnNum::Double) {
             value |= 0x08;
         }
-        if matches!(self.j6_turn_num, J6TurnNum::Double) {
+        if matches!(self.t_turn_num, TAxisTurnNum::Double) {
             value |= 0x10;
         }
-        if matches!(self.j1_turn_num, J1TurnNum::Double) {
+        if matches!(self.s_turn_num, SAxisTurnNum::Double) {
             value |= 0x20;
         }
-        if matches!(self.redundant_j1_placement, RedundantJ1Placement::Back) {
+        if matches!(self.redundant_s_placement, RedundantSAxisPlacement::Back) {
             value |= 0x40;
         }
         if matches!(self.ik_solution_basis, IkSolutionBasis::Configuration) {
@@ -171,9 +207,9 @@ impl ExtendedConfiguration {
     #[must_use]
     pub const fn from_raw(value: u8) -> Self {
         Self {
-            bit0: if value & 0x01 == 0 { J2TurnNum::Single } else { J2TurnNum::Double },
-            bit1: if value & 0x02 == 0 { J3TurnNum::Single } else { J3TurnNum::Double },
-            bit2: if value & 0x04 == 0 { J5TurnNum::Single } else { J5TurnNum::Double },
+            bit0: if value & 0x01 == 0 { LAxisTurnNum::Single } else { LAxisTurnNum::Double },
+            bit1: if value & 0x02 == 0 { UAxisTurnNum::Single } else { UAxisTurnNum::Double },
+            bit2: if value & 0x04 == 0 { BAxisTurnNum::Single } else { BAxisTurnNum::Double },
             bit3: if value & 0x08 == 0 { EAxisTurnNum::Single } else { EAxisTurnNum::Double },
             bit4: if value & 0x10 == 0 { WAxisTurnNum::Single } else { WAxisTurnNum::Double },
             bit5: value & 0x20 != 0, // Reserve
@@ -186,13 +222,13 @@ impl ExtendedConfiguration {
     #[must_use]
     pub const fn to_raw(self) -> u8 {
         let mut value = 0u8;
-        if matches!(self.bit0, J2TurnNum::Double) {
+        if matches!(self.bit0, LAxisTurnNum::Double) {
             value |= 0x01;
         }
-        if matches!(self.bit1, J3TurnNum::Double) {
+        if matches!(self.bit1, UAxisTurnNum::Double) {
             value |= 0x02;
         }
-        if matches!(self.bit2, J5TurnNum::Double) {
+        if matches!(self.bit2, BAxisTurnNum::Double) {
             value |= 0x04;
         }
         if matches!(self.bit3, EAxisTurnNum::Double) {
@@ -230,15 +266,25 @@ impl PulsePosition {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CartesianPosition {
+    // X [mm]
     pub x: f32,
+    // Y [mm]
     pub y: f32,
+    // Z [mm]
     pub z: f32,
+    // RX [deg]
     pub rx: f32,
+    // RY [deg]
     pub ry: f32,
+    // RZ [deg]
     pub rz: f32,
+    // Tool number
     pub tool_no: u8,
+    // User coordinate number
     pub user_coord_no: u8,
+    // Configuration
     pub configuration: Configuration,
+    // Extended configuration
     pub extended_configuration: ExtendedConfiguration,
 }
 
@@ -519,13 +565,13 @@ mod tests {
     #[test]
     fn test_configuration_serialization() {
         let configuration = Configuration::from_raw(0x55); // 01010101
-        assert_eq!(configuration.j1_placement, J1Placement::Back);
-        assert_eq!(configuration.j3_placement, J3Placement::Up);
-        assert_eq!(configuration.j5_placement, J5Placement::NoFlip);
-        assert_eq!(configuration.j4_turn_num, J4TurnNum::Single);
-        assert_eq!(configuration.j6_turn_num, J6TurnNum::Double);
-        assert_eq!(configuration.j1_turn_num, J1TurnNum::Single);
-        assert_eq!(configuration.redundant_j1_placement, RedundantJ1Placement::Back);
+        assert_eq!(configuration.s_placement, SAxisPlacement::Back);
+        assert_eq!(configuration.u_placement, UAxisPlacement::Up);
+        assert_eq!(configuration.b_placement, BAxisPlacement::NoFlip);
+        assert_eq!(configuration.r_turn_num, RAxisTurnNum::Single);
+        assert_eq!(configuration.t_turn_num, TAxisTurnNum::Double);
+        assert_eq!(configuration.s_turn_num, SAxisTurnNum::Single);
+        assert_eq!(configuration.redundant_s_placement, RedundantSAxisPlacement::Back);
         assert_eq!(configuration.ik_solution_basis, IkSolutionBasis::PreviousStep);
 
         let raw = configuration.to_raw();
@@ -535,9 +581,9 @@ mod tests {
     #[test]
     fn test_extended_configuration_serialization() {
         let extended_configuration = ExtendedConfiguration::from_raw(0x1F); // 00011111
-        assert_eq!(extended_configuration.bit0, J2TurnNum::Double);
-        assert_eq!(extended_configuration.bit1, J3TurnNum::Double);
-        assert_eq!(extended_configuration.bit2, J5TurnNum::Double);
+        assert_eq!(extended_configuration.bit0, LAxisTurnNum::Double);
+        assert_eq!(extended_configuration.bit1, UAxisTurnNum::Double);
+        assert_eq!(extended_configuration.bit2, BAxisTurnNum::Double);
         assert_eq!(extended_configuration.bit3, EAxisTurnNum::Double);
         assert_eq!(extended_configuration.bit4, WAxisTurnNum::Double);
         assert!(!extended_configuration.bit5);

--- a/moto-hses-proto/src/payload/position.rs
+++ b/moto-hses-proto/src/payload/position.rs
@@ -49,7 +49,9 @@ pub enum RedundantJ1Placement {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IkSolutionBasis {
+    // Select configuration that minimizes joint angle changes from the previous step
     PreviousStep,
+    // Prioritize the configuration attached to the position
     Configuration,
 }
 


### PR DESCRIPTION
## Overview

This PR renames form-related variables to configuration and improves configuration element naming for better clarity and consistency with robotics terminology.

## Major Changes

- 🏗️ **Refactor**: Rename Form struct to Configuration in position.rs
- 🏗️ **Refactor**: Rename ExtendedForm struct to ExtendedConfiguration  
- 🏗️ **Refactor**: Update all related enum and field names
- 🏗️ **Refactor**: Improve configuration element naming (J1Placement → SAxisPlacement, etc.)
- 🔧 **Improvement**: Update documentation in hses-protocol.md
- 🔧 **Improvement**: Improve naming consistency with robotics terminology
- 📝 **Documentation**: Add descriptive comments for axis types and angle ranges
- 📝 **Documentation**: Add field comments for CartesianPosition struct

## Technical Details

- Renamed `Form` struct to `Configuration` in `moto-hses-proto/src/payload/position.rs`
- Renamed `ExtendedForm` struct to `ExtendedConfiguration`
- Updated related enums: `RedundantJ1Placement`, `ReverseConversion` → `IkSolutionBasis`
- Updated field names: `form` → `configuration`, `extended_form` → `extended_configuration`
- Improved configuration element naming:
  - `J1Placement` → `SAxisPlacement` (Swing axis)
  - `J3Placement` → `UAxisPlacement` (Upper arm axis)
  - `J5Placement` → `BAxisPlacement` (Bend axis)
  - `J4TurnNum` → `RAxisTurnNum` (Rotate axis)
  - `J6TurnNum` → `TAxisTurnNum` (Twist axis)
  - `J1TurnNum` → `SAxisTurnNum` (Swing axis)
  - `J2TurnNum` → `LAxisTurnNum` (Lower arm axis)
  - `J3TurnNum` → `UAxisTurnNum` (Upper arm axis)
  - `J5TurnNum` → `BAxisTurnNum` (Bend axis)
- Added descriptive comments for axis types and angle ranges
- Added field comments for CartesianPosition struct (X, Y, Z, RX, RY, RZ, tool_no, user_coord_no)
- Updated documentation in `docs/specs/hses-protocol.md` to reflect new terminology
- Improved code readability and maintainability

## Breaking Changes

This is a refactoring change that renames internal structures and variables. The public API behavior remains the same, but variable names in the codebase have changed.

## Related Issues

<!-- No related issues -->