### PR TITLE
chore: prepare 0.1.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "moto-hses-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "env_logger",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "moto-hses-mock"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "env_logger",
  "log",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "moto-hses-proto"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "encoding_rs",

--- a/moto-hses-client/CHANGELOG.md
+++ b/moto-hses-client/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.1] - 2025-01-27
+## [0.1.2] - 2025-10-07
+
+### Changed
+- Update moto-hses-proto dependency to version 0.1
+
+## [0.1.1] - 2025-10-07
 
 ### Documentation
 - Add verified robot models and supported commands sections to README

--- a/moto-hses-client/Cargo.toml
+++ b/moto-hses-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moto-hses-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Async UDP client for Yaskawa High-Speed Ethernet Server (HSES) communication"
@@ -13,8 +13,8 @@ categories = ["network-programming", "asynchronous", "hardware-support"]
 readme = "README.md"
 
 [dependencies]
-moto-hses-proto = { version = "0.1.1", path = "../moto-hses-proto" }
-moto-hses-mock = { version = "0.1.1", path = "../moto-hses-mock" }
+moto-hses-proto = { version = "0.1", path = "../moto-hses-proto" }
+moto-hses-mock = { version = "0.1", path = "../moto-hses-mock" }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 futures = { workspace = true }

--- a/moto-hses-mock/CHANGELOG.md
+++ b/moto-hses-mock/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.1] - 2025-01-27
+## [0.1.2] - 2025-10-07
+
+### Changed
+- Update moto-hses-proto dependency to version 0.1
+
+## [0.1.1] - 2025-10-07
 
 ### Documentation
 - Add verified robot models and supported commands sections to README

--- a/moto-hses-mock/Cargo.toml
+++ b/moto-hses-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moto-hses-mock"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Mock HSES UDP server for testing and development"
@@ -13,7 +13,7 @@ categories = ["development-tools", "network-programming"]
 readme = "README.md"
 
 [dependencies]
-moto-hses-proto = { version = "0.1.1", path = "../moto-hses-proto" }
+moto-hses-proto = { version = "0.1", path = "../moto-hses-proto" }
 tokio = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }

--- a/moto-hses-proto/CHANGELOG.md
+++ b/moto-hses-proto/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.1] - 2025-01-27
+## [0.1.2] - 2025-10-07
+
+### Refactored
+- Rename form variables to configuration and improve axis naming for better robotics terminology
+
+## [0.1.1] - 2025-10-07
 
 ### Documentation
 - Add verified robot models and supported commands sections to README

--- a/moto-hses-proto/Cargo.toml
+++ b/moto-hses-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moto-hses-proto"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Protocol definitions and serialization for Yaskawa High-Speed Ethernet Server (HSES)"


### PR DESCRIPTION
## Overview

This PR prepares the 0.1.2 release with dependency updates and CHANGELOG entries.

## Major Changes

- 🔧 **Improvement**: Update moto-hses-client and moto-hses-mock CHANGELOG for 0.1.2
- 🔧 **Improvement**: Update dependency versions to 0.1 for automatic proto updates

## Technical Details

- Updated CHANGELOG.md in moto-hses-client and moto-hses-mock
- Changed dependency version from specific version to `0.1` to automatically use latest 0.1.x version
- This allows automatic updates when moto-hses-proto releases new patch versions

## Breaking Changes

None - this is a maintenance release.

## Related Issues

<!-- No related issues -->